### PR TITLE
remove block min-width

### DIFF
--- a/apps/block/stylesheets/sidebar.styl
+++ b/apps/block/stylesheets/sidebar.styl
@@ -1,6 +1,5 @@
 .block-sidebar
   width unit * 18
-  min-width unit * 18
   height 100vh
   background white
   overflow auto


### PR DESCRIPTION
section extends beyond screen width on small iphone, removing min constraint