### PR TITLE
Do not trigger an add if the model is not found

### DIFF
--- a/lib/vendor/backpusher.js
+++ b/lib/vendor/backpusher.js
@@ -88,6 +88,8 @@ _ = require('underscore');
 
         return model;
       }
+      // This used to add the model if not found
+      // but we removed it.
     },
 
     destroyed: function(pushed_model) {

--- a/lib/vendor/backpusher.js
+++ b/lib/vendor/backpusher.js
@@ -87,8 +87,6 @@ _ = require('underscore');
         model.trigger('remote_update', model);
 
         return model;
-      } else {
-        return this._add(pushed_model);
       }
     },
 


### PR DESCRIPTION
This is just due to Backpusher making some stupid assumptions.  Sending an update when a connection is removed is technically correct, we just don't want to add the model if it doesn't already exist.

Closes https://github.com/aredotna/ervell/issues/533