### PR TITLE
Set filter mode with cookie on profile

### DIFF
--- a/apps/user/index.coffee
+++ b/apps/user/index.coffee
@@ -11,6 +11,7 @@ app = module.exports = express()
 app.set "views", __dirname + "/templates"
 app.set "view engine", "jade"
 
+# API for user channels view
 app.get "/api/:username/channels", routes.fetchAuthor, routes.channelsAPI
 
 # All routes below need an author to render
@@ -37,5 +38,18 @@ app.get "/:username/block/:block_id", routes.user
 app.get "/:username/show/:block_id", routes.catchChannel
 app.get "/users/:username", routes.redirectUser
 
+# Middleware to determine what type of profile to show when the mode isn't specified
+filterMiddleware = (req, res, next) ->
+  filter = req.cookies.filter or "all"
+  switch filter
+    when "all"
+      return next()
+    when "channels"
+      return res.redirect 302, "/#{req.params.username}/channels"
+    when "index"
+      return res.redirect 302, "/#{req.params.username}/index"
+    when "blocks"
+      return res.redirect 302, "/#{req.params.username}/blocks"
+
 # Default profile view
-app.get "/:username", routes.fetchAuthor, sortMiddleware, routes.user, routes.catchChannel
+app.get "/:username", filterMiddleware, routes.fetchAuthor, sortMiddleware, routes.user, routes.catchChannel

--- a/apps/user/templates/metadata_pockets/view.jade
+++ b/apps/user/templates/metadata_pockets/view.jade
@@ -2,15 +2,35 @@ extends ../../../../components/meta_pocket/templates/meta_pocket
 
 block vars
   - title = "View"
-  - extraClasses = ''
+  - extraClasses = 'js-profile-filter'
   - id = "metadata--view"
 
 block content
   ul.breadcrumb
     - var sort = sd.SORT ? "?sort=" + sd.SORT : ""
 
-    li: a(href="/#{author.get('slug')}#{sort}" class=sd.SUBJECT ? "" : "is-active" ).metadata--selector__option All
-    li: a(href="/#{author.get('slug')}/channels#{sort}" class=sd.SUBJECT == 'channel' ? "is-active" : "").metadata--selector__option Channels
-    li: a(href="/#{author.get('slug')}/blocks#{sort}" class=sd.SUBJECT == 'block' ? "is-active" : "").metadata--selector__option Blocks
-    li: a(href="/#{author.get('slug')}/index" class=sd.SUBJECT == 'index' ? "is-active" : "").metadata--selector__option Index
+    li
+      a(
+        href="/#{author.get('slug')}#{sort}"
+        class=sd.SUBJECT ? "" : "is-active" 
+        data-filter="all"
+      ).js-filter-option.metadata--selector__option All
+    li
+      a(
+        href="/#{author.get('slug')}/channels#{sort}"
+        class=sd.SUBJECT == 'channel' ? "is-active" : ""
+        data-filter="channels"
+      ).js-filter-option.metadata--selector__option Channels
+    li
+      a(
+        href="/#{author.get('slug')}/blocks#{sort}"
+        class=sd.SUBJECT == 'block' ? "is-active" : ""
+        data-filter="blocks"
+      ).js-filter-option.metadata--selector__option Blocks
+    li
+      a(
+        href="/#{author.get('slug')}/index"
+        class=sd.SUBJECT == 'index' ? "is-active" : ""
+        data-filter="index"
+      ).js-filter-option.metadata--selector__option Index
 

--- a/components/path/client/path_view.coffee
+++ b/components/path/client/path_view.coffee
@@ -9,6 +9,7 @@ FollowButtonView = require '../../follow_button/client/follow_button_view.coffee
 PrivateChannelView = require '../../private_channel/client/private_channel_view.coffee'
 
 SortView = require '../components/sort/view.coffee'
+FilterView = require '../components/filter/view.coffee'
 
 module.exports = class PathView extends Backbone.View
 
@@ -25,6 +26,10 @@ module.exports = class PathView extends Backbone.View
       unless sd.CHANNEL
         new SortView
           el: @$('.js-profile-sort')
+          model: mediator.shared.state
+        
+        new FilterView
+          el: @$('.js-profile-filter')
           model: mediator.shared.state
           
         new PrivateChannelView

--- a/components/path/components/filter/view.coffee
+++ b/components/path/components/filter/view.coffee
@@ -1,0 +1,9 @@
+Backbone = require 'backbone'
+
+module.exports = class FilterView extends Backbone.View
+  events:
+    'click .js-filter-option' : 'updateFilter'
+    
+  updateFilter: (e) ->
+    filter = $(e.currentTarget).data('filter')
+    @model.set filter: filter

--- a/models/ui_state.coffee
+++ b/models/ui_state.coffee
@@ -7,6 +7,7 @@ module.exports = class UIState extends Backbone.Model
     view_mode: 'grid'
     lightbox: false
     sort: 'updated_at'
+    filter: 'all'
 
   initialize: ->
     # set values from cookies
@@ -15,6 +16,7 @@ module.exports = class UIState extends Backbone.Model
 
     @on 'change:view_mode', @setCookie
     @on 'change:sort', @setCookie
+    @on 'change:filter', @setCookie
 
   setCookie: (model, value)->
     cookies.set keys(model.changed)[0], value


### PR DESCRIPTION
Same deal as the sort, this one is a little more specific to the profile, so kept the middleware inline.

Also, a minor difference is that you are immediately redirected (instead of just displaying the content like the sort version). This felt a little less confusing than having the route stay `/:username` but having it mean different things. Open to other ideas.