### PR TITLE
Display API returned errors

### DIFF
--- a/apps/settings/components/payment_methods/index.jade
+++ b/apps/settings/components/payment_methods/index.jade
@@ -32,10 +32,10 @@ form
       | Continue my premium membership ($#{customer.get('current_plan_amount')} / #{customer.get('current_plan_term')}) on
       | #{customer.formatDate('current_period_end_at', 'D MMMM, YYYY')}
 
-  h3 Card Info
-
   .form-card__errors.js-form-errors
     //- Rendered client-side
+
+  h3 Card Info
 
   .Fieldset
     .Input.js-card-element

--- a/apps/settings/components/payment_methods/view.coffee
+++ b/apps/settings/components/payment_methods/view.coffee
@@ -138,14 +138,14 @@ module.exports = class PaymentMethodsView extends Backbone.View
           label: 'Plan type'
           value: @model.get('plan_id')
 
-      .catch (error) =>
+      .catch ({ responseJSON: { message, description }}) =>
         $target
           .prop 'disabled', false
-          .text 'Error'
+          .text message
 
         @els.errors
           .show()
-          .text error.message
+          .text description
 
     track.click en.PREMIUM_CHARGE_INITIATED,
       label: 'Plan type'
@@ -174,14 +174,14 @@ module.exports = class PaymentMethodsView extends Backbone.View
 
         $target.text 'Thank you!'
 
-      .catch (error) =>
+      .catch ({ responseJSON: { message, description }}) =>
         $target
           .prop 'disabled', false
-          .text 'Error'
+          .text message
 
         @els.errors
           .show()
-          .text error.message
+          .text description
 
   postRender: ->
     @els =


### PR DESCRIPTION
These were following Stripe's library error signature when they should be displaying errors from the server.