### PR TITLE
Adds support for video blocks (.mp4 & .mov files).

### DIFF
--- a/apps/block/stylesheets/index.styl
+++ b/apps/block/stylesheets/index.styl
@@ -124,9 +124,15 @@ block-sidebar-breakpoint = 950px
     fill textgray
 
 .block-video
+  margin 0 auto
+  max-width 65%
+  +below(block-sidebar-breakpoint)
+    max-width 100%
+
   video
-    max-width 65%
-    height auto
+    max-height 75vh
+    width auto
+    max-width 100%
 
 .block-meta--attribution
   position absolute

--- a/apps/block/templates/content_inner.jade
+++ b/apps/block/templates/content_inner.jade
@@ -11,7 +11,12 @@ if block.get('class') === 'Text'
   .block-text( id="attribute-content_#{block.id}" )
     != md(block.get('content'))
 
-if block.get('class') === 'Attachment' && !block.has('image')
+if block.isMovie()
+  .block-video
+    a( href= block.getSourceUrl() target='_blank' )
+      video( src= block.getSourceUrl(), controls)
+
+if block.get('class') === 'Attachment' && !block.has('image') && !block.isMovie()
   a.block-attachment( href= block.getSourceUrl() target='_blank' )
     if block.get('attachment').extension === 'mp3'
       img.iconic.iconic-lg(

--- a/components/block_collection/templates/types/attachment.jade
+++ b/components/block_collection/templates/types/attachment.jade
@@ -6,6 +6,12 @@ block content
       src="#{block.resizeImage()}"
       alt="#{block.get('description')}"
     ).grid__block__content__image
+  - else if (block.isMovie())
+    .valign--flex.halign--flex
+      video(
+        src= block.getSourceUrl()
+        muted
+      ).grid__block__content__image
   - else
     .valign--flex.halign--flex.grid__block__channel--attachment-bk
       if (block.get('attachment').extension == 'mp3' || block.get('attachment').extension == 'pdf')

--- a/components/blocks/grid_item/templates/types/attachment.jade
+++ b/components/blocks/grid_item/templates/types/attachment.jade
@@ -6,6 +6,12 @@ block content
       src="#{block.resizeImage()}"
       alt="#{block.get('description')}"
     ).grid__block__content__image
+  - else if (block.isMovie())
+    .valign--flex.halign--flex
+      video(
+        src= block.getSourceUrl()
+        muted
+      ).grid__block__content__image
   - else
     .valign--flex.halign--flex.grid__block__channel--attachment-bk
       if (block.get('attachment').extension == 'mp3' || block.get('attachment').extension == 'pdf')


### PR DESCRIPTION
Hello Are.na team,

I was a little bit sad when I saw the attachment icon on video blocks:
<img width="122" alt="screen shot 2017-08-08 at 13 30 37" src="https://user-images.githubusercontent.com/2735649/29070059-d10bde4c-7c3d-11e7-94b3-99803326f406.png">

I really want to create a channel for videos, especially now that VSCO is releasing video support! :)

From what I see on previous issues and code Are.na used to support it, no?

PS. There is no thumbnail attribute, that would make it easier for the grid view.