### PR TITLE
Centers attachment icon

### DIFF
--- a/apps/block/stylesheets/index.styl
+++ b/apps/block/stylesheets/index.styl
@@ -120,6 +120,7 @@ block-sidebar-breakpoint = 950px
       padding unit
 
 .block-attachment
+  margin 0 auto
   .iconic-property-fill
     fill textgray
 


### PR DESCRIPTION
Currently mis-aligned on blocks like: https://www.are.na/block/1135990