### PR TITLE
Modal close fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ MIN_FILE_SIZE = 1000
 
 # Start the server
 s:
-	REDIS_URL=redis://127.0.0.1:6379 API_URL=http://localhost:3000/v2 APP_URL=http://localhost:5000 foreman start
+	REDIS_URL=redis://127.0.0.1:6379 API_URL=http://localhost:3000/v2 APP_URL=http://localhost:5000 GRAPHQL_ENDPOINT=http://localhost:3000/graphql foreman start
 
 # Start the server with foreman and Redis
 spc:

--- a/components/layout/body/view.coffee
+++ b/components/layout/body/view.coffee
@@ -104,7 +104,7 @@ module.exports = class BodyView extends Backbone.View
     href = $(e.currentTarget).attr("href")
     target = $(e.currentTarget).attr("target") || '_self'
 
-    unless href?.indexOf(location.hostname) > -1 or href is '#'
+    unless href?.indexOf(location.hostname) > -1 or href is '#' or !href
       e.preventDefault()
       e.stopImmediatePropagation()
       trackOutboundLink href


### PR DESCRIPTION
In Safari 11, closing the modal triggers `about:blank` to open when the lightbox closes, the offending code is what handles tracking outbound links for analytics.