### PR TITLE
Moves cursor to end of input when coupon code re-renders

### DIFF
--- a/apps/settings/components/coupon_code/view.coffee
+++ b/apps/settings/components/coupon_code/view.coffee
@@ -35,7 +35,8 @@ module.exports = class CouponCodeView extends Backbone.View
     @els = input: @$('.js-input')
 
     @els.input.focus()
-    @els.input.val @els.input.val()
+    @els.input.val val = @els.input.val()
+    @els.input[0].setSelectionRange(val.length, val.length)
 
   render: ->
     @$el.html template


### PR DESCRIPTION
I guess there was some sort of change in the default behavior here when you replace a value.