### PR TITLE
Prepare pages for app launch

### DIFF
--- a/apps/about/stylesheets/index.styl
+++ b/apps/about/stylesheets/index.styl
@@ -16,6 +16,11 @@
     max-width 60%
     fill colors-gray-text
 
+.AppImg
+  display block
+  width 95%
+  margin 0 auto
+
 .AboutVideo
   width 100%
   position relative

--- a/apps/about/templates/faqs.jade
+++ b/apps/about/templates/faqs.jade
@@ -61,7 +61,7 @@ block container
     h3.Type.Type--size-h3
       | Is there an Are.na mobile app?
     p.Type.Type--lg.Type--lh-tall
-      | There will be an Are.na mobile app very soon! We’ll be announcing the release in November 2017.
+      | Yes, we just released an Are.na mobile app for iPhone. You can download it #[a(href=sd.ITUNES_LINK) here].
     h3.Type.Type--size-h3
       | How do I hide my public channels and profile from search engines?
     p.Type.Type--lg.Type--lh-tall

--- a/apps/about/templates/index.jade
+++ b/apps/about/templates/index.jade
@@ -58,6 +58,19 @@ block container
           a.Button.Button--size-lg( href='/about#pricing' )
             | Join Premium
 
+    section.AboutSection.js-section
+      h2.Type.Type--size-h2.Utility--align-center
+        | Are.na for iOS
+
+      img.AppImg(src="https://d2w9rnfcy7mm78.cloudfront.net/1511380/original_6b488f85f0d8bde6c073b91c02473a79.jpg")
+
+      p.Type.Type--lh-tall
+        | The Are.na mobile app lets you add content, browse channels, and make connections right from your phone. Take your ideas with you and browse a universe of shared knowledge, no matter where you are.
+
+      .AboutSection__buttons
+        a.Button.Button--size-lg( href=sd.ITUNES_LINK )
+          | Download Are.na for iOS
+
     section.AboutSection.js-section( id='labs' )
       h2.Type.Type--size-h2.Utility--align-center
         | Are.na Labs

--- a/apps/home/stylesheets/responsive.styl
+++ b/apps/home/stylesheets/responsive.styl
@@ -70,10 +70,16 @@
 
       > .Button
         flex-basis 50%
+        margin 1em
+
+        &--join
+          display none
+
+        &--app
+          display block
+
         &:first-child
           margin-right 0.5em
-        &:last-child
-          margin-left 0.5em
 
     &__footer
       margin-top 4em

--- a/apps/home/stylesheets/section.styl
+++ b/apps/home/stylesheets/section.styl
@@ -19,7 +19,7 @@
   &__cta
     display flex
     width 100%
-    flex-direction row
+    flex-flow row wrap
     justify-content center
     align-items center
     // Match font size to button size
@@ -31,8 +31,11 @@
       display block
       margin 0 1em
       max-width block_width
-      flex-basis 15%
+      flex-basis 10%
       white-space nowrap
+
+      &--app
+        display none
 
   &__footer
     padding 1em

--- a/apps/home/templates/sections/hero.jade
+++ b/apps/home/templates/sections/hero.jade
@@ -5,7 +5,9 @@
   include _splash_blocks
 
   .HomeSection__cta
-    a.Button.Button--size-lg( href='/sign_up' )
+    a.Button.Button--size-lg.Button--join( href='/sign_up' )
       | Join
+    a.Button.Button--size-lg.Button--app( href=sd.ITUNES_LINK )
+      | Download Are.na for iOS 
     a.Button.Button--size-lg.js-to-fold
       | What is Are.na?

--- a/components/meta/templates/meta.jade
+++ b/components/meta/templates/meta.jade
@@ -16,6 +16,7 @@ link(rel="apple-touch-icon" href="#{sd.IMAGE_PATH}touch-icon-iphone.png")
 link(rel="apple-touch-icon" sizes="76x76" href="#{sd.IMAGE_PATH}touch-icon-ipad.png")
 link(rel="apple-touch-icon" sizes="120x120" href="#{sd.IMAGE_PATH}touch-icon-iphone-retina.png")
 link(rel="apple-touch-icon" sizes="152x152" href="#{sd.IMAGE_PATH}touch-icon-ipad-retina.png")
+meta(name="apple-itunes-app" content="app-id=#{sd.IOS_APP_ID}")
 link(rel="apple-touch-startup-image" href="#{sd.IMAGE_PATH}loading.png")
 
 //- safari

--- a/config.coffee
+++ b/config.coffee
@@ -27,6 +27,7 @@ module.exports =
   GOOGLE_ANALYTICS_ID: null
   STRIPE_PUBLISHABLE_KEY: null
   X_APP_TOKEN: null
+  IOS_APP_ID: 1299153149
   ADMIN_SLUGS: 'chris-sherron,charles-broskoski,damon-zucconi,daniel-pianetti,christopher-barley,meg-miller,christina-badal,leo-shaw'
 
 # Override any values with env variables if they exist

--- a/config.coffee
+++ b/config.coffee
@@ -28,6 +28,7 @@ module.exports =
   STRIPE_PUBLISHABLE_KEY: null
   X_APP_TOKEN: null
   IOS_APP_ID: 1299153149
+  ITUNES_LINK: null
   ADMIN_SLUGS: 'chris-sherron,charles-broskoski,damon-zucconi,daniel-pianetti,christopher-barley,meg-miller,christina-badal,leo-shaw'
 
 # Override any values with env variables if they exist


### PR DESCRIPTION
This:
- Adds a link on the about page
- Adds a link on the FAQ
- Adds a link to download, replacing the join button for mobile browsers
- Adds the smart banner meta tag (later on, we can actually configure it to open the corresponding page in the app, at least for channels and profiles)

<img width="327" alt="screenshot 2017-12-16 09 59 43" src="https://user-images.githubusercontent.com/821469/34071787-1c6225e6-e24a-11e7-81c5-ae9b9faac1fb.png">
<img width="1387" alt="screenshot 2017-12-16 10 12 43" src="https://user-images.githubusercontent.com/821469/34071786-1c572e48-e24a-11e7-87f8-c1d1a6607591.png">