### PR TITLE
Add support for extended characters in channel index group headers

### DIFF
--- a/apps/user/templates/index.jade
+++ b/apps/user/templates/index.jade
@@ -1,16 +1,14 @@
 extends ../../../components/layout/index
 
 block body
-  - var range = '!~@#$%^&*()_-+=<>.,?/ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('')
-  - range.unshift('0-9')  
-
   include _path
   include _tips
-  
-  if _.keys(alpha).length
+
+  - var alphaKeys = _.sortBy(_.keys(alpha))
+  if alphaKeys.length
     .channel-container.flex-container.channel-container--alpha
       .alpha(class=channelsCount > 10 ? "alpha--two-columns" : "")
-        for letter in range
+        for letter in alphaKeys
           - group = alpha[letter]
           if group
             .alpha__group


### PR DESCRIPTION
I created a channel with a name containing Chinese characters and noticed that it wasn't showing up in the channel index.

This PR adds support for extended characters (e.g., CJK, emoji) in the groupings on the channel index page.

I changed the channel grouping list to rely on JavaScript's built-in sorting rather than a whitelist.

A couple of things to note:

- [ ] The order of numbers and symbols has swapped; the symbol groups now come before the numbers
  - I can tweak this behavior so it stays the same, if it's a big deal
- [ ] Emojis don't appear to render correctly
  - If I `console.log(alphaKeys)` the emoji is already turned into '�'

See the screenshots below:

### Before

![screen shot 2017-12-16 at 11 50 52 pm](https://user-images.githubusercontent.com/1486634/34076647-6d90354a-e2bb-11e7-8e60-069906add981.png)

### After

![screen shot 2017-12-16 at 11 51 37 pm](https://user-images.githubusercontent.com/1486634/34076653-98ece788-e2bb-11e7-9984-182335250231.png)

![screen shot 2017-12-16 at 11 52 02 pm](https://user-images.githubusercontent.com/1486634/34076682-74bdd7d6-e2bc-11e7-8171-ba3c263cf256.png)
