### PR TITLE
Fixes dragging link into bookmarklet (closes #901)

### DIFF
--- a/apps/marklet/components/marklet/view.coffee
+++ b/apps/marklet/components/marklet/view.coffee
@@ -69,9 +69,10 @@ module.exports = class MarkletView extends Backbone.View
 
   onDrop: (data) ->
     $html = $(data.value['text/html'])
+    text = data.value['text/plain']
     src = $html.find('img').attr('src')
     src = $html.first().next().attr('src') unless src
-    href = $html.first().next().attr('href') unless src
+    href = if !src and isURL(text) then text
 
     # Dropped a link
     if href?


### PR DESCRIPTION
The only case when we should set this as a link is if you click and drag a link directly into the bookmarklet, not if dragged text includes a link.

