### PR TITLE
More specific rules for disallowing indexing

### DIFF
--- a/apps/block/routes.coffee
+++ b/apps/block/routes.coffee
@@ -19,7 +19,7 @@ _ = require 'underscore'
     res.locals.sd.BLOCK = block.toJSON()
     res.locals.sd.COMMENTS = comments.toJSON()
     res.locals.sd.CURRENT_ACTION = 'block'
-    canIndexConnections = _.all block.get('connections'), (c) -> c.can_index
+    canIndexConnections = _.all block.get('connections'), (c) -> c.user?.can_index
     canIndexUser = block.get('user')?.can_index
 
     res.render 'index',

--- a/apps/block/routes.coffee
+++ b/apps/block/routes.coffee
@@ -19,7 +19,7 @@ _ = require 'underscore'
     res.locals.sd.BLOCK = block.toJSON()
     res.locals.sd.COMMENTS = comments.toJSON()
     res.locals.sd.CURRENT_ACTION = 'block'
-    canIndexConnections = _.all block.get('connections'), (c) -> c.can_index is true
+    canIndexConnections = _.all block.get('connections'), (c) -> c.can_index
     canIndexUser = block.get('user')?.can_index
 
     res.render 'index',

--- a/apps/block/routes.coffee
+++ b/apps/block/routes.coffee
@@ -19,11 +19,14 @@ _ = require 'underscore'
     res.locals.sd.BLOCK = block.toJSON()
     res.locals.sd.COMMENTS = comments.toJSON()
     res.locals.sd.CURRENT_ACTION = 'block'
+    canIndexConnections = _.all block.get('connections'), (c) -> c.can_index is true
+    canIndexUser = block.get('user')?.can_index
 
     res.render 'index',
       block: block
       comments: comments
       md: markdown
+      canIndex: canIndexUser && canIndexConnections
       tab: req.params.tab || 'info'
       connections: block.connections()
 

--- a/apps/block/templates/meta.jade
+++ b/apps/block/templates/meta.jade
@@ -10,3 +10,6 @@ if block.has('image')
 - description = (block.has('description') && block.get('description').replace(/(?:\r\n|\r|\n)/g, ' ')) || "Are.na is a social platform for creative and collaborative research."
 meta(name="twitter:description", content=description)
 meta(property="og:description" content=description)
+
+unless canIndex
+  meta(name="robots" content="none")

--- a/apps/channel/templates/_meta.jade
+++ b/apps/channel/templates/_meta.jade
@@ -11,7 +11,7 @@ if channel.get('status') == 'private'
   meta(name="robots" content="none")
 
 //- Do not index channels who's users have turned off search indexing
-unless channel.get('can_index')
+unless channel.get('can_index') || followers
   meta(name="robots" content="none")
 
 //- Standard channel meta

--- a/apps/user/templates/_meta.jade
+++ b/apps/user/templates/_meta.jade
@@ -6,7 +6,7 @@ link(
   href="https://www.are.na/#{author.get('slug')}/feed/rss"
 )
 
-unless author.get('can_index')
+unless author.get('can_index') || followers || following
   meta(name="robots" content="none")
 
 meta(name="twitter:title", content="Are.na / #{author.get('username')}")


### PR DESCRIPTION
- [x] no index on following and follower pages
- [x] no index on block pages when any of the connected channels are owned by a user with indexing turned off