### PR TITLE
Don't show invest CTA on the settings page

### DIFF
--- a/lib/middleware/locals.coffee
+++ b/lib/middleware/locals.coffee
@@ -19,6 +19,12 @@ module.exports = (req, res, next) ->
   # TODO: remove after campaign
   # only show if the user is logged in and confirmed
   # and hasn't closed the CTA
-  res.locals.showInvestCTA = (!req.cookies['invest_cta']? and req.user and req.user.get('is_confirmed'))
+  # and is not on the settings page.
+  res.locals.showInvestCTA = (
+    !req.cookies['invest_cta']? and
+    req.user and
+    req.user.get('is_confirmed') and
+    res.locals.sd.CURRENT_PATH.indexOf('/settings') < 0
+  )
 
   next()


### PR DESCRIPTION
Re: bug report

> When you've just created an account or accepted an invitation there are some things going on in the footer and they block the save button on the Setting page. Particularly the invest campaign banner gets in the way - I couldn't see how to save my changes until I dismissed that banner.