### PR TITLE
Clear notifications (but don't mark them as read) when dropdown is open

### DIFF
--- a/collections/notifications.coffee
+++ b/collections/notifications.coffee
@@ -21,6 +21,9 @@ module.exports = class Notifications extends Feed
     @addOrMergeNew data
     mediator.trigger 'notification:added'
 
+  clear: ->
+    $.post "#{sd.API_URL}/notifications/clear"
+
   markRead: ->
     mediator.shared.current_user.resetNotificationCount()
     @each (group)->
@@ -28,7 +31,7 @@ module.exports = class Notifications extends Feed
 
     mediator.trigger 'notifications:cleared'
 
-    $.post "#{sd.API_URL}/notifications/clear"
+    @clear()
 
   getNumberUnread: ->
     count = 0

--- a/components/logged_in_navigation/components/notifications/view.coffee
+++ b/components/logged_in_navigation/components/notifications/view.coffee
@@ -16,11 +16,13 @@ module.exports = class NotificationsView extends Backbone.View
       .one 'mouseenter', =>
         @state.set('is_fetching', true)
         Promise(@collection.fetch())
-          .then => @state.set('is_fetching', false)
+          .then =>
+            @collection.clear()
+            @state.set('is_fetching', false)
 
-      .one 'mouseleave click', =>
-        @collection.markRead()
+      .on 'mouseleave click', (e) =>
         @state.set('unread_count', 0)
+        @collection.markRead()
 
   render: ->
     @$el.html template


### PR DESCRIPTION
Fixes an annoying issue where notifications are not cleared when you click on an item (because the XHR is intercepted). This calls `clear` when the notifications are loaded, and "marks" them later.