### PR TITLE
Fixes for loader in Chrome

### DIFF
--- a/apps/marklet/public/loader.js
+++ b/apps/marklet/public/loader.js
@@ -61,7 +61,7 @@
       "#arena_frame.is-expanded{height:"+markletHeightExpanded+"px !important}" +
       "#arena_frame{z-index:9999999998;background:rgba(255,255,255,0.75);}" +
       "#arena_frame:hover{background:rgba(255,255,255,0.9);}" +
-      "#arena_div{z-index:9999999999;display:none;opacity:0}";
+      "#arena_div{z-index:9999999999;display:none;}";
 
     if (markletStyle.styleSheet) {
       markletStyle.styleSheet.cssText = markletCSS;


### PR DESCRIPTION
:HUGE SHRUG:

I'm very curious as to what is actually going on here. I'm assuming that there's some kind of optimization in Chrome 67 that disables event listeners on invisible elements or something.