### PR TITLE
Issue 866: Validate email addresses on invite form

### DIFF
--- a/apps/tools/components/send_invitation/index.coffee
+++ b/apps/tools/components/send_invitation/index.coffee
@@ -8,8 +8,12 @@ module.exports = ($el) ->
   $submit = $el.find '.js-submit'
   $errors = $el.find '.js-errors'
 
+  submissionTimeout = null;
+
   $form.on 'submit', (e) ->
     e.preventDefault()
+
+    submissionTimeout && clearTimeout(submissionTimeout);
 
     serializer = new Serializer $form
 
@@ -31,7 +35,7 @@ module.exports = ($el) ->
         .prop 'disabled', false
         .text 'Sent!'
 
-      setTimeout (-> $submit.text label), 2500
+      submissionTimeout = setTimeout (-> $submit.text label), 2500
 
       track.submit 'Invitation sent from user'
 
@@ -47,9 +51,26 @@ module.exports = ($el) ->
         .prop 'disabled', false
         .text 'Error'
 
-      setTimeout ->
+      submissionTimeout = setTimeout ->
         $submit.text label
         $errors.empty()
       , 5000
 
       track.error 'Invitation not sent, try again.'
+
+    .catch ->
+      $errors
+        .show()
+        .html """
+          Something went wrong, please contact <a href='mailto:info@are.na'>info@are.na</a> if the problem persists.
+        """
+
+      $submit
+        .prop 'disabled', false
+        .text label
+
+      submissionTimeout = setTimeout ->
+        $errors.empty()
+      , 15000
+
+      track.error 'Invitation not sent: server error. Try again.'

--- a/apps/tools/components/send_invitation/index.coffee
+++ b/apps/tools/components/send_invitation/index.coffee
@@ -41,7 +41,7 @@ module.exports = ($el) ->
   $form.on 'submit', (e) ->
     e.preventDefault()
 
-    submissionTimeout && clearTimeout(submissionTimeout);
+    clearTimeout(submissionTimeout)
 
     serializer = new Serializer $form
 

--- a/apps/tools/components/send_invitation/index.coffee
+++ b/apps/tools/components/send_invitation/index.coffee
@@ -45,6 +45,8 @@ module.exports = ($el) ->
 
     serializer = new Serializer $form
 
+    $errors.empty()
+
     $submit
       .prop 'disabled', true
       .text 'Sending...'


### PR DESCRIPTION
# Overview

References [#866](https://github.com/aredotna/ervell/issues/866).

- [x] Add catch-all error handling in case server responds with 500 (can happen if the `type='email'` on the frontend form ever fails to catch errant values).
- [x] Better timeout handling for UI updates to prevent prior requests from making UI updates on top of subsequent requests.
- [x] Not technically part of this PR, but I added Disposable Email checking in the sibling [API Pull Request](https://github.com/aredotna/api/pull/656) for this PR.

Notes:

This PR is marked WIP because of the following: 

Currently the existing code appears to stop the behaviour described in  [#866](https://github.com/aredotna/ervell/issues/866), at least in major browsers, because of the `type='email'` on the frontend form's input element, which makes me think [#866](https://github.com/aredotna/ervell/issues/866) needs more explanation. 

That said, I do think that relying on `type='email'` can be unreliable and is better off to move away from. To that end, I added some questions on the sibling [API Pull Request](https://github.com/aredotna/api/pull/656) for this PR.

If we want to do more validation server side, the changes to the form in this PR should accommodate them.

# Screenshots

### Chrome, Default Email Input Behaviour
![image](https://user-images.githubusercontent.com/806129/42550796-cd0e3872-84a1-11e8-8ed6-fa00a66045c5.png)

### Firefox, Default Email Input Behaviour
![image](https://user-images.githubusercontent.com/806129/42550806-d80d63ce-84a1-11e8-8a1a-0b73300222b2.png)

### Disposable Email Handling
![image](https://user-images.githubusercontent.com/806129/42550871-3bf13352-84a2-11e8-801e-4629c739823b.png)

### Catch-All (500 etc) Error Handling
![image](https://user-images.githubusercontent.com/806129/42550892-70bb4208-84a2-11e8-8279-5902302d686b.png)
