### PR TITLE
Properly handles non-graphQL errors (related to #1405)

### DIFF
--- a/react/util/__tests__/mapErrors.js
+++ b/react/util/__tests__/mapErrors.js
@@ -1,6 +1,39 @@
 import mapErrors from 'react/util/mapErrors';
 
 describe('mapErrors', () => {
+  describe('handles errors with no graphQL errors', () => {
+    const ERROR = new Error('This is an error.');
+
+    it('handles the error properly', () => {
+      expect(mapErrors(ERROR))
+        .toEqual({
+          attributeErrors: {},
+          errorMessage: 'This is an error.',
+        });
+    });
+  });
+
+  describe('a response with multiple attribute errors', () => {
+    const RESPONSE = {
+      data: { registration: null },
+      errors: [{
+        message: "doesn't match Password", locations: [{ line: 2, column: 3 }], path: ['registration'], extensions: { code: 'UNPROCESSABLE_ENTITY', attribute: 'password_confirmation' },
+      }, {
+        message: 'is too short (minimum is 6 characters)', locations: [{ line: 2, column: 3 }], path: ['registration'], extensions: { code: 'UNPROCESSABLE_ENTITY', attribute: 'password' },
+      }],
+    };
+
+    it('maps the error messages into their respective attributes', () => {
+      expect(mapErrors({ graphQLErrors: RESPONSE.errors }))
+        .toEqual({
+          attributeErrors: {
+            password: 'is too short (minimum is 6 characters)',
+            password_confirmation: "doesn't match Password",
+          },
+          errorMessage: null,
+        });
+    });
+  });
   describe('a response with no attribute errors and a single overall error', () => {
     const RESPONSE = {
       data: { registration: null },

--- a/react/util/__tests__/mapErrors.js
+++ b/react/util/__tests__/mapErrors.js
@@ -13,27 +13,6 @@ describe('mapErrors', () => {
     });
   });
 
-  describe('a response with multiple attribute errors', () => {
-    const RESPONSE = {
-      data: { registration: null },
-      errors: [{
-        message: "doesn't match Password", locations: [{ line: 2, column: 3 }], path: ['registration'], extensions: { code: 'UNPROCESSABLE_ENTITY', attribute: 'password_confirmation' },
-      }, {
-        message: 'is too short (minimum is 6 characters)', locations: [{ line: 2, column: 3 }], path: ['registration'], extensions: { code: 'UNPROCESSABLE_ENTITY', attribute: 'password' },
-      }],
-    };
-
-    it('maps the error messages into their respective attributes', () => {
-      expect(mapErrors({ graphQLErrors: RESPONSE.errors }))
-        .toEqual({
-          attributeErrors: {
-            password: 'is too short (minimum is 6 characters)',
-            password_confirmation: "doesn't match Password",
-          },
-          errorMessage: null,
-        });
-    });
-  });
   describe('a response with no attribute errors and a single overall error', () => {
     const RESPONSE = {
       data: { registration: null },

--- a/react/util/mapErrors.js
+++ b/react/util/mapErrors.js
@@ -6,7 +6,7 @@ const MEMO = {
 };
 
 module.exports = (err = {}) => {
-  if (err.graphQLErrors.length === 0) {
+  if (!err.graphQLErrors || err.graphQLErrors.length === 0) {
     return { ...MEMO, errorMessage: err.message };
   }
 


### PR DESCRIPTION
This does not close the issue, but at least displays an error and sets the state properly.