### PR TITLE
Fixed edit channel/group

### DIFF
--- a/react/components/ManageChannel/index.js
+++ b/react/components/ManageChannel/index.js
@@ -6,6 +6,7 @@ import { some } from 'underscore';
 import styled from 'styled-components';
 
 import mapErrors from 'react/util/mapErrors';
+import compactObject from 'react/util/compactObject';
 
 import manageChannelFragment from 'react/components/ManageChannel/fragments/manageChannel';
 import manageChannelQuery from 'react/components/ManageChannel/queries/manageChannel';
@@ -34,23 +35,11 @@ class ManageChannel extends Component {
     onClose: PropTypes.func.isRequired,
   }
 
-  static getDerivedStateFromProps(nextProps) {
-    const { data: { loading } } = nextProps;
-    if (loading) return null;
-
-    const { data: { channel: { title, description, visibility } } } = nextProps;
-    return {
-      title,
-      description,
-      visibility: visibility.toUpperCase(),
-    };
-  }
-
   state = {
     mode: 'resting',
-    title: '',
-    description: '',
-    visibility: '',
+    title: null,
+    description: null,
+    visibility: null,
     attributeErrors: {},
     errorMessage: '',
   };
@@ -86,11 +75,11 @@ class ManageChannel extends Component {
 
     this.setState({ mode: 'submitting' });
 
-    return updateChannel({
-      variables: {
-        id, title, description, visibility,
-      },
-    })
+    const variables = compactObject({
+      id, title, description, visibility,
+    });
+
+    return updateChannel({ variables })
       .then(({ data: { update_channel: { channel: { href } } } }) => {
         onClose();
         // Slug may have changed so redirect
@@ -108,8 +97,6 @@ class ManageChannel extends Component {
     const { data: { loading } } = this.props;
     const {
       mode,
-      title,
-      description,
       visibility,
       attributeErrors,
       errorMessage,
@@ -137,9 +124,10 @@ class ManageChannel extends Component {
 
             <Input
               name="title"
-              value={title}
+              defaultValue={channel.title}
               onChange={this.handleTitle}
               errorMessage={attributeErrors.title}
+              required
             />
           </LabelledInput>
 
@@ -150,7 +138,7 @@ class ManageChannel extends Component {
 
             <Textarea
               name="description"
-              value={description || ''}
+              defaultValue={channel.description}
               onChange={this.handleDescription}
               placeholder="describe your channel here"
               rows="3"
@@ -166,7 +154,7 @@ class ManageChannel extends Component {
             <div>
               <Select
                 name="visibility"
-                value={visibility.toUpperCase()}
+                defaultValue={channel.visibility.toUpperCase()}
                 onChange={this.handleVisbility}
               >
                 <option value="PUBLIC">Open</option>
@@ -179,7 +167,7 @@ class ManageChannel extends Component {
                   PUBLIC: 'Everyone can view the channel and anyone logged-in can add to it.',
                   CLOSED: 'Everyone can view the channel but only you and your collaborators can add to it.',
                   PRIVATE: 'Only you and your collaborators can view and add to the channel.',
-                }[visibility.toUpperCase()]}
+                }[(visibility || channel.visibility).toUpperCase()]}
               </Text>
             </div>
           </LabelledInput>

--- a/react/components/ManageChannel/mutations/updateChannel.js
+++ b/react/components/ManageChannel/mutations/updateChannel.js
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import manageChannelFragment from 'react/components/ManageChannel/fragments/manageChannel';
 
 export default gql`
-  mutation updateChannelMutation($id: ID!, $title: String!, $description: String, $visibility: ChannelVisibility) {
+  mutation updateChannelMutation($id: ID!, $title: String, $description: String, $visibility: ChannelVisibility) {
     update_channel(input: { id: $id, title: $title, description: $description, visibility: $visibility }) {
       channel {
         ...ManageChannel

--- a/react/components/ManageGroup/index.js
+++ b/react/components/ManageGroup/index.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import { propType } from 'graphql-anywhere';
 import { compose, graphql } from 'react-apollo';
 
+import compactObject from 'react/util/compactObject';
+
 import manageGroupFragment from 'react/components/ManageGroup/fragments/manageGroup';
 import manageGroupQuery from 'react/components/ManageGroup/queries/manageGroup';
 import collaboratorsListQuery from 'react/components/ChannelMetadata/components/ChannelMetadataCollaborators/queries/collaboratorsList';
@@ -43,17 +45,9 @@ class ManageGroup extends Component {
     }).isRequired,
   }
 
-  static getDerivedStateFromProps(nextProps) {
-    const { data: { loading } } = nextProps;
-    if (loading) return null;
-
-    const { data: { group: { name } } } = nextProps;
-    return { name };
-  }
-
   state = {
     mode: 'resting',
-    name: '',
+    name: null,
   }
 
   handleName = ({ target: { value: name } }) => {
@@ -101,12 +95,7 @@ class ManageGroup extends Component {
       default:
         this.setState({ mode: 'submitting' });
 
-        return updateGroup({
-          variables: {
-            id,
-            name,
-          },
-        })
+        return updateGroup({ variables: compactObject({ id, name }) })
           .then(onClose)
           .catch((err) => {
             console.error(err);
@@ -167,7 +156,7 @@ class ManageGroup extends Component {
     this.setState({ mode: 'resting' });
 
   renderDialog() {
-    const { mode, name } = this.state;
+    const { mode } = this.state;
     const { data: { group, group: { owner, memberships } } } = this.props;
 
     switch (mode) {
@@ -200,7 +189,7 @@ class ManageGroup extends Component {
                 name="name"
                 placeholder="enter group name"
                 onChange={this.handleName}
-                value={name}
+                defaultValue={group.name}
                 disabled={!group.can.manage}
               />
             </LabelledInput>
@@ -228,8 +217,8 @@ class ManageGroup extends Component {
                 onRemove={this.handleRemoveUser}
                 confirmationWarning="Are you sure?"
                 confirmationSelfWarning={`
-                  Removing yourself from ${name} means you will
-                  lose access to all channels ${name} is collaborating on.
+                  Removing yourself from ${group.name} means you will
+                  lose access to all channels ${group.name} is collaborating on.
                   There is no way to undo this action, and only the group’s
                   creator can re-add you.
                 `}

--- a/react/components/ManageGroup/mutations/updateGroup.js
+++ b/react/components/ManageGroup/mutations/updateGroup.js
@@ -3,7 +3,7 @@ import gql from 'graphql-tag';
 import manageGroupFragment from 'react/components/ManageGroup/fragments/manageGroup';
 
 export default gql`
-  mutation updateGroupMutation($id: ID!, $name: String!) {
+  mutation updateGroupMutation($id: ID!, $name: String) {
     update_group(input: { id: $id, name: $name }) {
       group {
         ...ManageGroup

--- a/react/util/__tests__/compactObject.js
+++ b/react/util/__tests__/compactObject.js
@@ -8,11 +8,13 @@ describe('compactObject', () => {
       c: null,
       d: 1,
       e: 0,
+      f: '',
     })).toEqual({
       a: 'foo',
       b: false,
       d: 1,
       e: 0,
+      f: '',
     });
   });
 });


### PR DESCRIPTION
Some boring reading: https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html

In general setting the state from the props should be frowned upon. Which makes sense if you think about how in these cases we went from sending the ALL the fields, even if they weren't updated, to now, only the updated ones.

I also need to fix a tiny bug in the update channel mutation which is disallowing deleting descriptions.