### PR TITLE
Add Tabs component

### DIFF
--- a/react/components/UI/Tabs/components/Tab/index.js
+++ b/react/components/UI/Tabs/components/Tab/index.js
@@ -29,7 +29,7 @@ const Label = styled.div.attrs({ fontSize: 3 })`
   ${x => x.active && activeMixin};
 `;
 
-export default class TabList extends Component {
+export default class Tab extends Component {
   static propTypes = {
     label: PropTypes.string.isRequired,
     onTabClick: PropTypes.func.isRequired,

--- a/react/components/UI/Tabs/components/Tab/index.js
+++ b/react/components/UI/Tabs/components/Tab/index.js
@@ -1,0 +1,57 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+import { baseMixin } from 'react/components/UI/Text';
+import { space } from 'styled-system';
+
+import { preset } from 'react/styles/functions';
+
+export const activeMixin = css`
+  border-top: 2px solid ${x => x.theme.colors.gray.bold};
+  border-left: 1px solid ${x => x.theme.colors.gray.regular};
+  border-right: 1px solid ${x => x.theme.colors.gray.regular};
+  border-bottom: 1px solid ${x => x.theme.colors.gray.light};
+  color: ${x => x.theme.colors.gray.bold};
+  background-color: ${x => x.theme.colors.gray.light};
+`;
+
+const Label = styled.div.attrs({ fontSize: 3 })`
+  text-align: center;
+  border: 1px solid transparent;
+  border-top: 2px solid transparent;
+  cursor: pointer;
+  margin-bottom: -1px;
+  font-weight: bold;
+
+  ${preset(space, { pt: 5, pb: 6, px: 9 })};
+  ${baseMixin};
+
+  ${x => x.active && activeMixin};
+`;
+
+export default class TabList extends Component {
+  static propTypes = {
+    label: PropTypes.string.isRequired,
+    onTabClick: PropTypes.func.isRequired,
+    active: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    active: false,
+  }
+
+  onTabClick = () => {
+    const { onTabClick, label } = this.props;
+    onTabClick(label);
+  }
+
+  render() {
+    const { label, active } = this.props;
+
+    return (
+      <Label active={active} onClick={this.onTabClick}>
+        {label}
+      </Label>
+    );
+  }
+}

--- a/react/components/UI/Tabs/index.js
+++ b/react/components/UI/Tabs/index.js
@@ -50,6 +50,7 @@ export default class Tabs extends Component {
     const { children } = this.props;
     const { activeTab } = this.state;
     const labels = children.map(child => (child.props.label));
+    const content = children.find(child => child.props.label === activeTab);
 
     return (
       <Container>
@@ -64,10 +65,7 @@ export default class Tabs extends Component {
           ))}
         </TabList>
         <TabContent>
-          {children.map((child) => {
-            if (child.props.label !== activeTab) return undefined;
-            return child;
-          })}
+          {content}
         </TabContent>
       </Container>
     );

--- a/react/components/UI/Tabs/index.js
+++ b/react/components/UI/Tabs/index.js
@@ -1,9 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import styled, { css } from 'styled-components';
-import { fontSize, space } from 'styled-system';
-
-import { preset } from 'react/styles/functions';
+import styled from 'styled-components';
+import Tab from 'react/components/UI/Tabs/components/Tab';
 
 const Container = styled.div`
   display: flex;
@@ -21,42 +19,16 @@ const TabList = styled.div`
 
 const TabContent = styled.div`
   display: flex;
-  background-color: ${x => x.activeBackgroundColor};
-`;
-
-export const activeMixin = css`
-  border-top: 2px solid ${x => x.theme.colors.gray.bold};
-  border-left: 1px solid ${x => x.theme.colors.gray.regular};
-  border-right: 1px solid ${x => x.theme.colors.gray.regular};
-  border-bottom: 1px solid ${x => x.activeBackgroundColor};
-  color: ${x => x.theme.colors.gray.bold};
-  background-color: ${x => x.activeBackgroundColor};
-`;
-
-const Label = styled.div`
-  text-align: center;
-  border: 1px solid transparent;
-  border-top: 2px solid transparent;
-  cursor: pointer;
-  font-family: ${x => x.theme.fonts.sans};
-  font-weight: bold;
-  margin-bottom: -2px;
-
-  ${preset(space, { pt: 5, pb: 6, px: 9 })};
-  ${preset(fontSize, { f: 2 })};
-
-  ${x => x.active && activeMixin};
+  background-color: ${x => x.theme.colors.gray.light};
 `;
 
 export default class Tabs extends Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
-    activeBackgroundColor: PropTypes.string,
     activeTab: PropTypes.string,
   }
 
   static defaultProps = {
-    activeBackgroundColor: '#fff',
     activeTab: null,
   }
 
@@ -75,28 +47,23 @@ export default class Tabs extends Component {
   }
 
   render() {
-    const { props: { children, activeBackgroundColor }, state: { activeTab } } = this;
+    const { children } = this.props;
+    const { activeTab } = this.state;
+    const labels = children.map(child => (child.props.label));
 
     return (
       <Container>
         <TabList>
-          {children.map((child) => {
-            const { label } = child.props;
-            const active = activeTab === label;
-
-            return (
-              <Label
-                activeBackgroundColor={activeBackgroundColor}
-                active={active}
-                key={label}
-                onClick={() => this.onTabClick(label)}
-              >
-                {label}
-              </Label>
-            );
-          })}
+          {labels.map(label => (
+            <Tab
+              active={activeTab === label}
+              key={label}
+              onTabClick={this.onTabClick}
+              label={label}
+            />
+          ))}
         </TabList>
-        <TabContent activeBackgroundColor={activeBackgroundColor}>
+        <TabContent>
           {children.map((child) => {
             if (child.props.label !== activeTab) return undefined;
             return child;

--- a/react/components/UI/Tabs/index.js
+++ b/react/components/UI/Tabs/index.js
@@ -1,0 +1,108 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+import { fontSize, space } from 'styled-system';
+
+import { preset } from 'react/styles/functions';
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const TabList = styled.div`
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  flex-direction: row;
+  display: flex;
+  border-bottom: 1px solid ${x => x.theme.colors.gray.regular};
+`;
+
+const TabContent = styled.div`
+  display: flex;
+  background-color: ${x => x.activeBackgroundColor};
+`;
+
+export const activeMixin = css`
+  border-top: 2px solid ${x => x.theme.colors.gray.bold};
+  border-left: 1px solid ${x => x.theme.colors.gray.regular};
+  border-right: 1px solid ${x => x.theme.colors.gray.regular};
+  border-bottom: 1px solid ${x => x.activeBackgroundColor};
+  color: ${x => x.theme.colors.gray.bold};
+  background-color: ${x => x.activeBackgroundColor};
+`;
+
+const Label = styled.div`
+  text-align: center;
+  border: 1px solid transparent;
+  border-top: 2px solid transparent;
+  cursor: pointer;
+  font-family: ${x => x.theme.fonts.sans};
+  font-weight: bold;
+  margin-bottom: -2px;
+
+  ${preset(space, { pt: 5, pb: 6, px: 9 })};
+  ${preset(fontSize, { f: 2 })};
+
+  ${x => x.active && activeMixin};
+`;
+
+export default class Tabs extends Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    activeBackgroundColor: PropTypes.string,
+    activeTab: PropTypes.string,
+  }
+
+  static defaultProps = {
+    activeBackgroundColor: '#fff',
+    activeTab: null,
+  }
+
+  constructor(props) {
+    super(props);
+
+    const { activeTab, children } = props;
+
+    this.state = {
+      activeTab: (activeTab || children[0].props.label),
+    };
+  }
+
+  onTabClick = (tab) => {
+    this.setState({ activeTab: tab });
+  }
+
+  render() {
+    const { props: { children, activeBackgroundColor }, state: { activeTab } } = this;
+
+    return (
+      <Container>
+        <TabList>
+          {children.map((child) => {
+            const { label } = child.props;
+            const active = activeTab === label;
+
+            return (
+              <Label
+                activeBackgroundColor={activeBackgroundColor}
+                active={active}
+                key={label}
+                onClick={() => this.onTabClick(label)}
+              >
+                {label}
+              </Label>
+            );
+          })}
+        </TabList>
+        <TabContent activeBackgroundColor={activeBackgroundColor}>
+          {children.map((child) => {
+            if (child.props.label !== activeTab) return undefined;
+            return child;
+          })}
+        </TabContent>
+      </Container>
+    );
+  }
+}

--- a/react/stories/Tabs.stories.js
+++ b/react/stories/Tabs.stories.js
@@ -24,24 +24,6 @@ storiesOf('Tabs', module)
         <Text p={2}>{lorem.paragraphs()}</Text>
       </div>
     </Tabs>
-  )).add('with colored background', () => (
-    <Tabs activeBackgroundColor="#eee">
-      <div label="Section A">
-        <Text p={2}>{lorem.paragraphs()}</Text>
-      </div>
-
-      <div label="Section B">
-        <Text p={2}>{lorem.paragraphs()}</Text>
-      </div>
-
-      <div label="Section C">
-        <Text p={2}>{lorem.paragraphs()}</Text>
-      </div>
-
-      <div label="Section D">
-        <Text p={2}>{lorem.paragraphs()}</Text>
-      </div>
-    </Tabs>
   )).add('with inital active tab set', () => (
     <Tabs activeTab="Section D">
       <div label="Section A">

--- a/react/stories/Tabs.stories.js
+++ b/react/stories/Tabs.stories.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { lorem } from 'faker';
+
+import Tabs from 'react/components/UI/Tabs';
+import Text from 'react/components/UI/Text';
+
+storiesOf('Tabs', module)
+  .add('default', () => (
+    <Tabs>
+      <div label="Section A">
+        <Text p={2}>{lorem.paragraphs()}</Text>
+      </div>
+
+      <div label="Section B">
+        <Text p={2}>{lorem.paragraphs()}</Text>
+      </div>
+
+      <div label="Section C">
+        <Text p={2}>{lorem.paragraphs()}</Text>
+      </div>
+
+      <div label="Section D">
+        <Text p={2}>{lorem.paragraphs()}</Text>
+      </div>
+    </Tabs>
+  )).add('with colored background', () => (
+    <Tabs activeBackgroundColor="#eee">
+      <div label="Section A">
+        <Text p={2}>{lorem.paragraphs()}</Text>
+      </div>
+
+      <div label="Section B">
+        <Text p={2}>{lorem.paragraphs()}</Text>
+      </div>
+
+      <div label="Section C">
+        <Text p={2}>{lorem.paragraphs()}</Text>
+      </div>
+
+      <div label="Section D">
+        <Text p={2}>{lorem.paragraphs()}</Text>
+      </div>
+    </Tabs>
+  )).add('with inital active tab set', () => (
+    <Tabs activeTab="Section D">
+      <div label="Section A">
+        <Text p={2}>{lorem.paragraphs()}</Text>
+      </div>
+
+      <div label="Section B">
+        <Text p={2}>{lorem.paragraphs()}</Text>
+      </div>
+
+      <div label="Section C">
+        <Text p={2}>{lorem.paragraphs()}</Text>
+      </div>
+
+      <div label="Section D">
+        <Text p={2}>{lorem.paragraphs()}</Text>
+      </div>
+    </Tabs>
+  ));


### PR DESCRIPTION
Putting together a Tabs component for the new groups / education / examples pages. This is pretty minimal atm, I imagine we will eventually want more but want to keep it as minimal as possible for now.

---

See mockup here:
![screen shot 2018-11-01 at 2 19 40 pm](https://user-images.githubusercontent.com/821469/47879679-961ddc00-ddf7-11e8-9af0-5fe96b61691f.png)

See storybook screenshots:
![screen shot 2018-11-01 at 5 00 19 pm](https://user-images.githubusercontent.com/821469/47879704-a766e880-ddf7-11e8-8b61-9864fd047a65.png)
![screen shot 2018-11-01 at 5 01 35 pm](https://user-images.githubusercontent.com/821469/47879762-cebdb580-ddf7-11e8-8e80-621beddd3ba9.png)

