### PR TITLE
Fixes default value

### DIFF
--- a/config.coffee
+++ b/config.coffee
@@ -10,8 +10,8 @@ module.exports =
   PORT: 4000
   APP_URL: "http://localhost:4000"
   API_BASE: "http://api.are.na"
-  GRAPHQL_ENDPOINT: "http://api.are.na/graphql"
-  CLIENT_GRAPHQL_ENDPOINT: "http://api.are.na/graphql"
+  GRAPHQL_ENDPOINT: "https://api.are.na/graphql"
+  CLIENT_GRAPHQL_ENDPOINT: null
   API_URL: "http://api.are.na/v2"
   PUSHER_KEY: '19beda1f7e2ca403abab'
   S3_KEY: null

--- a/react/apollo/index.js
+++ b/react/apollo/index.js
@@ -21,7 +21,7 @@ const isClientSide = typeof window !== 'undefined';
 
 const { data: { GRAPHQL_ENDPOINT, CLIENT_GRAPHQL_ENDPOINT } } = sharify;
 
-const clientHttpLink = createHttpLink({ uri: CLIENT_GRAPHQL_ENDPOINT });
+const clientHttpLink = createHttpLink({ uri: CLIENT_GRAPHQL_ENDPOINT || GRAPHQL_ENDPOINT });
 const serverHttpLink = createHttpLink({ uri: GRAPHQL_ENDPOINT });
 
 const fragmentMatcher = new IntrospectionFragmentMatcher({


### PR DESCRIPTION
I personally find it weird that you can have GRAPHQL_ENDPOINT set to something like localhost but then this comes in. Unfortunately the way this is set up makes it semi-odd to set fallback to an alternate env variable. I'd rather it fail hard than fail mysteriously and work correctly for more cases.