### PR TITLE
Fixes double set headers in login & null response crashes

### DIFF
--- a/lib/passport/index.coffee
+++ b/lib/passport/index.coffee
@@ -60,16 +60,17 @@ respond = (req, res, next) ->
     user: req.user.toJSON()
 
 error = (err, req, res, next) ->
-  console.error(err.stack)
+  if req.xhr and err.response?
+    # Propagate the error response to the client
+    res
+      .status err.response.status
+      .send err.response.data
+
+    return
 
   # Pass on to next error handler
   # if this is not an XHR request
-  next(err) unless req.xhr
-
-  # Propagate the error response to the client
-  res
-    .status err.response.status
-    .send err.response.data
+  next(err)
 
 addLocals = (req, res, next) ->
   if req.user

--- a/react/components/LoginForm/index.js
+++ b/react/components/LoginForm/index.js
@@ -75,7 +75,12 @@ export default class LoginForm extends Component {
     this.setState({ mode: 'submitting' });
 
     return axios
-      .post('/me/sign_in', { email, password })
+      .post('/me/sign_in', { email, password }, {
+        headers: {
+          // Sets `req.xhr` in Express
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+      })
 
       .then(() => {
         this.setState({ mode: 'redirecting' });

--- a/react/components/RegistrationForm/index.js
+++ b/react/components/RegistrationForm/index.js
@@ -109,7 +109,14 @@ class RegistrationForm extends Component {
     return mutation({ variables })
       .then(() => {
         this.setState({ mode: 'logging_in' });
-        return axios.post('/me/sign_in', { email, password });
+
+        return axios
+          .post('/me/sign_in', { email, password }, {
+            headers: {
+              // Sets `req.xhr` in Express
+              'X-Requested-With': 'XMLHttpRequest',
+            },
+          });
       })
       .then(() => {
         this.setState({ mode: 'redirecting' });


### PR DESCRIPTION
So two things:

* Axios weirdly doesn't set the header needed by Express to set the `xhr` attribute.
* And we were flat out crashing if an error without a response happened (probably timeouts)