### PR TITLE
Fixes link to items in feed

### DIFF
--- a/react/components/Feed/components/FeedGroupSentence/index.js
+++ b/react/components/Feed/components/FeedGroupSentence/index.js
@@ -70,8 +70,13 @@ export default class FeedGroupSentence extends PureComponent {
           {action !== 'commented' &&
             <span>
               <Label>
-                {` ${action} ${item_phrase} `}
+                {` ${action} `}
               </Label>
+
+
+              {item &&
+                <FeedObjectLink {...item} label={item_phrase} />
+              }
 
               {connector &&
                 <Label>


### PR DESCRIPTION
I didn't really understand what this was. This should just be a prop on the item itself aliased to label instead of having to do this manually but it looks like the schema's out of wack or something.