### PR TITLE
Do not show dispatch message if the user is newly joined

### DIFF
--- a/components/layout/client.coffee
+++ b/components/layout/client.coffee
@@ -3,6 +3,7 @@ Backbone.$ = $
 sd = require('sharify').data
 Cookies = require 'cookies-js'
 _ = require 'underscore'
+moment =  require 'moment'
 BodyView = require './body/view.coffee'
 MessageView = require '../message/view.coffee'
 HeaderInfoView = require './header/client.coffee'

--- a/components/layout/client.coffee
+++ b/components/layout/client.coffee
@@ -162,11 +162,13 @@ showDispatchMessage = ->
   # or if they have a pending confirmation.
   # or if they are premium
   # or if we are already showing them a message for exceeding the limit
-  
+  # or if they just joined less than five minutes ago
+
   shouldReturn = !current_user.id or
     current_user.get('is_pending_confirmation') or
     current_user.get('is_premium') or
-    current_user.get('is_exceeding_private_connections_limit')
+    current_user.get('is_exceeding_private_connections_limit') or
+    moment().isAfter(moment(current_user.get('created_at')).add(5, 'minutes'))
 
   return if shouldReturn
 


### PR DESCRIPTION
The dispatch pop-up would show up in onboarding when a person was invited (and thus already confirmed).