### PR TITLE
Adds a filter to ignore the large amount of 404/401 errors we get

### DIFF
--- a/lib/setup.coffee
+++ b/lib/setup.coffee
@@ -82,6 +82,16 @@ airbrake = new AirbrakeClient({
   projectKey: AIRBRAKE_API_KEY,
 })
 
+airbrake.addFilter (notice) ->
+  return null if (
+    # Ignores 404s
+    (notice.errors[0].message is 'Not found') or
+    # Ignores 401s
+    (notice.errors[0].message is 'Access denied')
+  )
+
+  notice
+
 module.exports = (app) ->
   console.log "Setting up... NODE_ENV=#{NODE_ENV}"
 


### PR DESCRIPTION
Closes https://github.com/aredotna/ervell/issues/1706

I still think we should:

* Avoid 404ing on missing profile or channels and instead return a tailored message
![](http://static.damonzucconi.com/_capture/kod1NCQYq1.png)

* Avoid 401ing since that would confirm the existence of a channel/profile with a specific slug which could be considered leaking some level of information about it