### PR TITLE
Only attempts to connect when the environment variable for Redis is present

### DIFF
--- a/src/lib/cache.coffee
+++ b/src/lib/cache.coffee
@@ -25,6 +25,8 @@ retry_strategy = (options) ->
 
 # Setup redis client
 @connect = () ->
+  return unless REDIS_URL?
+
   @client = redis.createClient(REDIS_URL, { retry_strategy: retry_strategy })
   @client.on 'error', (err) ->
     # Log + ignore the error; start up without Redis


### PR DESCRIPTION
Not sure why but attempts to connect to a bogus REDIS_URL are failing in staging (though I can't replicate this locally). For now removing the url entirely.