### PR TITLE
Add regenerator runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "react-transition-group": "^1.2.0",
     "react-waypoint": "^8.1.0",
     "redis": "*",
+    "regenerator-runtime": "^0.13.2",
     "rupture": "*",
     "serve-favicon": "^2.3.0",
     "sharify": "*",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 /* eslint-disable no-console */
-require('dotenv').config();
 
-// require('newrelic');
+require('dotenv').config();
+require('regenerator-runtime/runtime');
+require('newrelic');
 require('coffee-register');
 require('@babel/register')({
   extensions: ['.js', '.jsx', '.ts', '.tsx'],

--- a/src/lib/global_modules.js
+++ b/src/lib/global_modules.js
@@ -1,3 +1,4 @@
+import 'regenerator-runtime/runtime';
 import _ from 'underscore';
 import $ from 'jquery';
 import imagesLoaded from 'imagesloaded';


### PR DESCRIPTION
Babel 7 handles polyfill stuff differently than babel 6, via the `preset-env` plugin. See https://babeljs.io/docs/en/babel-preset-env#usebuiltins. 

That said, sometimes the regenerator will still need to be imported. I can take a better look at this later but this should get things to a deployable state. 