### PR TITLE
Precompile server code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ dump.rdb
 manifest.json
 yarn-error.log
 newrelic_agent.log
+
+# Compiled server code
+server.dist.js
+server.dist.js.map

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node --optimize_for_size --max_old_space_size=920 src/index.js
+web: node --optimize_for_size --max_old_space_size=920 server.dist.js

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "assets": "sh scripts/assets.sh",
     "build": "yarn webpack --config ./webpack/webpack.config.js",
+    "build:server": "BUILD_SERVER=true NODE_ENV=production yarn build",
     "deploy-staging": "sh scripts/deploy-staging.sh",
     "deploy-storybook": "storybook-to-ghpages",
     "deploy": "sh scripts/deploy.sh",
@@ -15,7 +16,8 @@
     "mocha": "sh scripts/mocha.sh",
     "predeploy": "sh scripts/predeploy.sh",
     "restart-dyno": "node bin/restart",
-    "start": "node --max_old_space_size=4096 -r dotenv/config src/index.js",
+    "start": "node -r dotenv/config src/index.js",
+    "start:prod": "node -r dotenv/config server.dist.js",
     "start-dev": "yarn start dotenv_config_path=./.env.staging",
     "start-prod": "yarn start dotenv_config_path=./.env.production",
     "storybook": "start-storybook -p 9001 -c .storybook",
@@ -176,6 +178,7 @@
   },
   "devDependencies": {
     "@babel/node": "^7.2.2",
+    "@babel/plugin-transform-modules-commonjs": "^7.4.3",
     "@storybook/addon-actions": "^5.0.10",
     "@storybook/addon-options": "^5.0.10",
     "@storybook/cli": "^5.0.10",
@@ -219,6 +222,7 @@
     "rewire": "^4.0.0",
     "should": "*",
     "sinon": "*",
+    "source-map-support": "^0.5.12",
     "storybook-react-router": "^1.0.5",
     "typescript": "3.3.3",
     "webpack": "^4.30.0",
@@ -227,6 +231,7 @@
     "webpack-dev-middleware": "^3.6.2",
     "webpack-hot-middleware": "^2.24.3",
     "webpack-merge": "^4.2.1",
+    "webpack-node-externals": "^1.7.2",
     "webpack-notifier": "^1.5.1"
   },
   "optionalDependencies": {

--- a/scripts/assets.sh
+++ b/scripts/assets.sh
@@ -5,6 +5,7 @@ set -e -x
 rm -rf public/assets
 mkdir public/assets
 NODE_ENV=production yarn build
+yarn build:server
 stylus \
   $(find src/assets -name '*.styl') \
   --compress \

--- a/src/apps/feed/middleware/homePath.js
+++ b/src/apps/feed/middleware/homePath.js
@@ -1,11 +1,11 @@
 export default (req, res, next) => {
-  if (!req.user) return next();
+  if (!req.user) return next()
 
-  const path = req.user.get('home_path');
+  const path = req.user.get('home_path')
 
-  if ((path != null) && path !== '/') {
-    res.redirect(302, path);
+  if (path != null && path !== '/') {
+    res.redirect(302, path)
   }
 
-  return next();
-};
+  return next()
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,15 @@
 /* eslint-disable no-console */
 
+require('source-map-support').install()
 require('regenerator-runtime/runtime')
 require('newrelic')
-require('coffee-register')
-require('@babel/register')({
-  extensions: ['.js', '.jsx', '.ts', '.tsx'],
-})
+
+if (process.env.NODE_ENV === 'development') {
+  require('coffee-register')
+  require('@babel/register')({
+    extensions: ['.ts', '.js', '.tsx', '.jsx'],
+  })
+}
 
 global.Promise = require('bluebird')
 

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -1,18 +1,18 @@
 declare module '*.png' {
-  const content: any;
-  export default content;
+  const content: any
+  export default content
 }
 
 declare module '*.svg' {
-  const content: any;
-  export default content;
+  const content: any
+  export default content
 }
 
 declare global {
   interface Window {
-    __APOLLO_CLIENT__: any;
-    __APOLLO_STATE__: any;
+    __APOLLO_CLIENT__: any
+    __APOLLO_STATE__: any
   }
 }
 
-export {};
+export {}

--- a/webpack/envs/index.js
+++ b/webpack/envs/index.js
@@ -1,0 +1,13 @@
+// @ts-check
+
+const baseConfig = require('./baseConfig')
+const developmentConfig = require('./developmentConfig')
+const productionConfig = require('./productionConfig')
+const serverConfig = require('./serverConfig')
+
+module.exports = {
+  baseConfig,
+  developmentConfig,
+  productionConfig,
+  serverConfig,
+}

--- a/webpack/envs/serverConfig.js
+++ b/webpack/envs/serverConfig.js
@@ -1,0 +1,52 @@
+// @ts-check
+
+const path = require('path')
+const webpack = require('webpack')
+const nodeExternals = require('webpack-node-externals')
+const baseConfig = require('./baseConfig')
+
+const { NODE_ENV } = process.env
+const rootDir = process.cwd()
+
+const serverConfig = {
+  mode: NODE_ENV,
+  devtool: 'source-map',
+  target: 'node',
+  externals: [nodeExternals()],
+  node: {
+    __dirname: true,
+  },
+  entry: path.join(rootDir, 'src/index.js'),
+  output: {
+    filename: 'server.dist.js',
+    path: path.resolve(rootDir),
+  },
+  module: {
+    rules: [
+      {
+        test: /(\.(js|ts)x?$)/,
+        include: path.resolve(rootDir, 'src'),
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              plugins: [['@babel/plugin-transform-modules-commonjs']],
+            },
+          },
+        ],
+      },
+      ...baseConfig.module.rules,
+    ],
+  },
+  plugins: [
+    new webpack.optimize.LimitChunkCountPlugin({
+      maxChunks: 1,
+    }),
+  ],
+  resolve: {
+    extensions: ['.js', '.jsx', '.ts', '.tsx', '.json', '.coffee'],
+    modules: [path.resolve(rootDir, 'src'), 'node_modules'],
+  },
+}
+
+module.exports = serverConfig

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -1,11 +1,15 @@
 // @ts-check
+/* eslint-disable no-console */
 
 const merge = require('webpack-merge')
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer')
 
-const baseConfig = require('./envs/baseConfig')
-const developmentConfig = require('./envs/developmentConfig')
-const productionConfig = require('./envs/productionConfig')
+const {
+  baseConfig,
+  developmentConfig,
+  productionConfig,
+  serverConfig,
+} = require('./envs')
 
 const { NODE_ENV = 'development' } = process.env
 const isDevelopment = NODE_ENV === 'development'
@@ -14,15 +18,16 @@ const BUILD_SERVER = process.env.BUILD_SERVER === 'true'
 const ANALYZE_BUNDLE = process.env.ANALYZE_BUNDLE === 'true'
 
 const getConfig = () => {
-  console.log(`\n[Ervell] NODE_ENV=${NODE_ENV} \n`) // eslint-disable-line
+  console.log(`\n[Ervell] NODE_ENV=${NODE_ENV} \n`)
 
   switch (true) {
+    case BUILD_SERVER:
+      console.log('[Ervell] Building server-side code...')
+      return serverConfig
     case isDevelopment:
       return merge.smart(baseConfig, developmentConfig)
     case isProduction:
       return merge.smart(baseConfig, productionConfig)
-    case BUILD_SERVER:
-      return true
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15400,18 +15400,18 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
-  integrity sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==
+source-map-support@^0.5.12, source-map-support@^0.5.9, source-map-support@~0.5.10:
+  version "0.5.12"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
+  integrity sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map-support@^0.5.9, source-map-support@~0.5.10:
-  version "0.5.12"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.12.tgz#b4f3b10d51857a5af0138d3ce8003b201613d599"
-  integrity sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==
+source-map-support@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
+  integrity sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
@@ -17150,6 +17150,11 @@ webpack-merge@^4.2.1:
   integrity sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==
   dependencies:
     lodash "^4.17.5"
+
+webpack-node-externals@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"
+  integrity sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==
 
 webpack-notifier@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
Adds a new webpack config (`serverConfig.js`) which precompiles server-side code into a flat `server.dist.js` file. This fixes boot times since individual apps no longer need to be compiled on the fly. 

New command:
```
yarn build:server
```

This can be optimized in the future, but to test a local prod build:
- Run `yarn build:server`
- Run `yarn bucket-assets --fingerprint false`
- Copy the output from `manifest.json` and paste into `ASSET_MANIFEST` in .env file
- Add `CDN_URL=''` to `.env`
- Run `NODE_ENV=production yarn start:prod`

![boot](https://user-images.githubusercontent.com/236943/56686593-293e1d00-6689-11e9-89c3-1aa91c9418cf.gif)
