### PR TITLE
Remove bucket-assets, replace with Webpack hashing

### DIFF
--- a/apollo.config.js
+++ b/apollo.config.js
@@ -1,19 +1,4 @@
-const fs = require('fs')
-
-const getEnv = () => {
-  switch (true) {
-    case fs.existsSync('.env'):
-      return '.env'
-    case fs.existsSync('.env.staging'):
-      return '.env.staging'
-    case fs.existsSync('.env.production'):
-      return '.env.production'
-  }
-}
-
-require('dotenv').config({
-  path: getEnv(),
-})
+require('./src/lib/loadEnv')
 
 // Configuration for the vscode-apollo extension and other Apollo tooling.
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "assets": "sh scripts/assets.sh",
     "build": "yarn webpack --config ./webpack/webpack.config.js",
     "build:server": "BUILD_SERVER=true NODE_ENV=production yarn build",
+    "clean": "rm -f manifest.json && rm -rf public/assets && mkdir -p public/assets && echo '[Ervell] Cleaned build directory'",
     "deploy-staging": "sh scripts/deploy-staging.sh",
     "deploy-storybook": "storybook-to-ghpages",
     "deploy": "sh scripts/deploy.sh",
@@ -23,7 +24,8 @@
     "storybook": "start-storybook -p 9001 -c .storybook",
     "sync-schema": "yarn run apollo schema:download src/v2/apollo/schema.json",
     "test": "sh scripts/test.sh",
-    "type-check": "yarn tsc"
+    "type-check": "yarn tsc",
+    "upload-to-s3": "node scripts/uploadToS3.js"
   },
   "engines": {
     "node": "10.x.x",
@@ -88,7 +90,6 @@
     "blueimp-file-upload": "git://github.com/arenahq/jQuery-File-Upload.git",
     "body-parser": "*",
     "body-scroll-lock": "^2.6.1",
-    "bucket-assets": "aredotna/bucket-assets.git#d253febf7c658673c036afc85d034572011135e4",
     "cheerio": "^0.22.0",
     "chroma-js": "^1.4.0",
     "coffee-loader": "^0.9.0",
@@ -221,6 +222,7 @@
     "prettier": "^1.17.0",
     "progress-bar-webpack-plugin": "^1.11.0",
     "rewire": "^4.0.0",
+    "s3": "^4.4.0",
     "should": "*",
     "sinon": "*",
     "source-map-support": "^0.5.12",
@@ -231,6 +233,7 @@
     "webpack-command": "^0.4.1",
     "webpack-dev-middleware": "^3.6.2",
     "webpack-hot-middleware": "^2.24.3",
+    "webpack-manifest-plugin": "^2.0.4",
     "webpack-merge": "^4.2.1",
     "webpack-node-externals": "^1.7.2",
     "webpack-notifier": "^1.5.1"

--- a/scripts/assets.sh
+++ b/scripts/assets.sh
@@ -2,8 +2,7 @@
 
 set -e -x
 
-rm -rf public/assets
-mkdir public/assets
+yarn clean
 NODE_ENV=production yarn build
 yarn build:server
 stylus \

--- a/scripts/predeploy.sh
+++ b/scripts/predeploy.sh
@@ -3,7 +3,4 @@
 set -e -x
 
 yarn assets
-gzip -S .cgz $(find public/assets -name '*.css')
-gzip -S .jgz $(find public/assets -name '*.js')
-bucket-assets --bucket $S3_BUCKET
-heroku config:set ASSET_MANIFEST=$(cat manifest.json) --app=$APP_NAME
+yarn upload-to-s3

--- a/scripts/uploadToS3.js
+++ b/scripts/uploadToS3.js
@@ -1,0 +1,73 @@
+/* eslint-disable no-console */
+
+const chalk = require('chalk')
+
+// @ts-check
+
+require('../src/lib/loadEnv')
+
+const glob = require('glob')
+const mime = require('mime')
+const path = require('path')
+const s3 = require('s3')
+const { last } = require('lodash')
+
+const options = {
+  root: 'public',
+  files: path.join(process.cwd(), '/**/public/**'),
+  key: process.env.S3_KEY,
+  secret: process.env.S3_SECRET,
+  bucket: process.env.S3_BUCKET,
+  cdnUrl: process.env.CDN_URL,
+}
+
+// See: https://www.npmjs.com/package/s3 for more options
+const client = s3.createClient({
+  s3Options: {
+    accessKeyId: options.key,
+    secretAccessKey: options.secret,
+  },
+})
+
+const files = glob.sync(options.files, {
+  ignore: 'node_modules',
+  nodir: true,
+})
+
+const generateHeaders = file => {
+  const extension = path.extname(file)
+  const contentType = mime.getType(extension)
+  return {
+    ACL: 'public-read',
+    CacheControl: 'max-age=315360000, public',
+    ContentType: contentType,
+  }
+}
+
+console.log(chalk.green('[uploadToS3] Starting S3 sync...\n'))
+
+files.forEach(file => {
+  const s3Path = last(file.split(options.root)).substring(1)
+  const uploader = client.uploadFile({
+    localFile: file,
+
+    // See: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property
+    s3Params: {
+      Bucket: options.bucket,
+      Key: s3Path,
+      ...generateHeaders(file),
+    },
+  })
+
+  uploader.on('error', err => {
+    console.error(
+      chalk.red(`[uploadToS3] Error uploading ${s3Path}.\n`),
+      err.stack,
+      '\n'
+    )
+  })
+
+  uploader.on('end', () => {
+    console.log(`[uploadToS3] ${s3Path}`)
+  })
+})

--- a/src/lib/loadEnv.js
+++ b/src/lib/loadEnv.js
@@ -1,0 +1,19 @@
+// @ts-check
+
+const fs = require('fs')
+const dotenv = require('dotenv')
+
+const getEnv = () => {
+  switch (true) {
+    case fs.existsSync('.env'):
+      return '.env'
+    case fs.existsSync('.env.staging'):
+      return '.env.staging'
+    case fs.existsSync('.env.production'):
+      return '.env.production'
+  }
+}
+
+dotenv.config({
+  path: getEnv(),
+})

--- a/src/lib/middleware/asset.ts
+++ b/src/lib/middleware/asset.ts
@@ -1,0 +1,37 @@
+import path from 'path'
+import fs from 'fs'
+import chalk from 'chalk'
+
+const { CDN_URL, NODE_ENV } = process.env
+const isProduction = NODE_ENV === 'production'
+
+export default function assetMiddleware() {
+  if (isProduction) {
+    const manifestPath = path.resolve(process.cwd(), 'manifest.json')
+
+    let manifest = {}
+    try {
+      manifest = JSON.parse(fs.readFileSync(manifestPath, { encoding: 'utf8' }))
+    } catch (error) {
+      console.error(chalk.red('\n[Ervell] Error parsing manifest:'), error)
+    }
+
+    return (_req, res, next) => {
+      res.locals.asset = filename => {
+        let manifestFile = manifest[filename] || filename
+        if (CDN_URL) {
+          manifestFile = CDN_URL + manifestFile
+        }
+        return manifestFile
+      }
+      next()
+    }
+
+    // Development, return the file being requested and don't look for a manifest
+  } else {
+    return (_req, res, next) => {
+      res.locals.asset = filename => filename
+      next()
+    }
+  }
+}

--- a/src/lib/setup.coffee
+++ b/src/lib/setup.coffee
@@ -37,7 +37,6 @@ session = require 'cookie-session'
 path = require 'path'
 logger = require 'morgan'
 multipart = require 'connect-multiparty'
-bucketAssets = require 'bucket-assets'
 favicon = require 'serve-favicon'
 blocker = require 'express-spam-referral-blocker'
 { createReloadable } = require '@artsy/express-reloadable'
@@ -52,8 +51,9 @@ viewModeMiddleware = require './middleware/view_mode'
 checkSessionMiddleware = require './middleware/check_session'
 isInverted = require '../components/night_mode/middleware'
 splitTestMiddleware = require '../components/split_test/middleware'
-{ default: ensureWWWMiddleware } = require './middleware/ensureWWW'
+{ default: assetMiddleware } = require "./middleware/asset"
 { default: isSpiderMiddleware } = require './middleware/isSpider'
+{ default: ensureWWWMiddleware } = require './middleware/ensureWWW'
 
 cache = require './cache'
 arenaPassport = require './passport'
@@ -133,7 +133,7 @@ module.exports = (app) ->
               .use(require('nib')())
 
   app
-    .use bucketAssets()
+    .use assetMiddleware()
     .use express.static(path.resolve __dirname, '../../public')
     .use favicon(path.resolve __dirname, '../../public/images/favicon.ico')
     .use logger('dev')

--- a/src/v2/components/ChannelMetadata/components/ChannelMetadataActions/components/MuteChannelButton/mutations/muteChannel.ts
+++ b/src/v2/components/ChannelMetadata/components/ChannelMetadataActions/components/MuteChannelButton/mutations/muteChannel.ts
@@ -5,6 +5,8 @@ import muteChannelButtonFragment from 'v2/components/ChannelMetadata/components/
 export default gql`
   mutation muteChannelMutation($id: ID!) {
     __typename
+
+    # FIXME: Deprecated field
     mute_channel(input: { id: $id }) {
       __typename
       channel {

--- a/src/v2/components/ChannelMetadata/components/ChannelMetadataActions/components/MuteChannelButton/mutations/unmuteChannel.ts
+++ b/src/v2/components/ChannelMetadata/components/ChannelMetadataActions/components/MuteChannelButton/mutations/unmuteChannel.ts
@@ -5,6 +5,8 @@ import muteChannelButtonFragment from 'v2/components/ChannelMetadata/components/
 export default gql`
   mutation unmuteChannelMutation($id: ID!) {
     __typename
+
+    # FIXME: Deprecated field
     unmute_channel(input: { id: $id }) {
       __typename
       channel {

--- a/src/v2/components/ManageCollaborators/components/ManageableCollaboratorSearch/mutations/inviteCollaborator.ts
+++ b/src/v2/components/ManageCollaborators/components/ManageableCollaboratorSearch/mutations/inviteCollaborator.ts
@@ -4,6 +4,7 @@ import manageCollaboratorsFragment from 'v2/components/ManageCollaborators/fragm
 
 export default gql`
   mutation inviteCollaborator($email: String!, $channel_id: ID!) {
+    # FIXME: Deprecated field
     invite_collaborator(input: { email: $email, channel_id: $channel_id }) {
       channel {
         ...ManageCollaborators

--- a/webpack/envs/baseConfig.js
+++ b/webpack/envs/baseConfig.js
@@ -10,6 +10,7 @@ const rootDir = process.cwd()
 
 const baseConfig = {
   mode: NODE_ENV,
+  devtool: 'cheap-module-source-map',
   context: rootDir,
   entry: {
     webpack: ['webpack-hot-middleware/client?reload=true'],
@@ -18,8 +19,7 @@ const baseConfig = {
   output: {
     filename: '[name].js',
     path: path.resolve(rootDir, 'public/assets'),
-    publicPath: '/assets',
-    sourceMapFilename: '[file].map?[contenthash]',
+    publicPath: '/assets/',
   },
   module: {
     rules: [

--- a/webpack/envs/productionConfig.js
+++ b/webpack/envs/productionConfig.js
@@ -1,9 +1,28 @@
 // @ts-check
 
-const { NODE_ENV } = process.env
+const path = require('path')
+const WebpackManifestPlugin = require('webpack-manifest-plugin')
+const { HashedModuleIdsPlugin } = require('webpack')
+const { getCSSManifest } = require('../utils/getCSSManifest')
+
+const { BUILD_SERVER, NODE_ENV } = process.env
+const isProduction = NODE_ENV === 'production'
+const buildCSS = isProduction && !BUILD_SERVER
 
 const productionConfig = {
   mode: NODE_ENV,
+  devtool: 'source-map',
+  output: {
+    filename: '[name].[contenthash].js',
+  },
+  plugins: [
+    new HashedModuleIdsPlugin(),
+    new WebpackManifestPlugin({
+      fileName: path.resolve(process.cwd(), 'manifest.json'),
+      basePath: '/assets/',
+      seed: buildCSS ? getCSSManifest() : {},
+    }),
+  ],
 }
 
 module.exports = productionConfig

--- a/webpack/utils/getCSSManifest.js
+++ b/webpack/utils/getCSSManifest.js
@@ -1,0 +1,79 @@
+/* eslint-disable no-console */
+
+const chalk = require('chalk')
+
+// @ts-check
+
+const glob = require('glob')
+const fs = require('fs')
+const path = require('path')
+const crypto = require('crypto')
+const { execSync } = require('child_process')
+const baseConfig = require('../envs/baseConfig')
+
+// Ouput
+const DEST = 'public/assets'
+
+// Tasks
+function clean() {
+  glob.sync(`${DEST}/*.{css,css.cgz}`).forEach(file => fs.unlinkSync(file))
+}
+
+function compile() {
+  console.log(chalk.green(`[Ervell compileCSS] Compiling...`))
+  const files = glob.sync('src/assets/*.styl', {
+    nodir: true,
+  })
+  execSync(`yarn stylus ${files.join(' ')} --compress -o ${DEST}`)
+}
+
+function fingerprint(file) {
+  const contents = fs.readFileSync(file)
+  const hash = crypto
+    .createHash('sha1')
+    .update(contents)
+    .digest('hex')
+    .slice(0, 21)
+  const ext = '.css'
+  const original = file.replace('public', '')
+  const fingerprinted = path.basename(file, ext) + '.' + hash + ext
+
+  try {
+    fs.renameSync(file, `${DEST}/${fingerprinted}`)
+  } catch (error) {
+    console.error('[Ervell compileCSS] Error renaming file:', error)
+  }
+
+  return {
+    original,
+    fingerprinted,
+  }
+}
+
+/**
+ * Return a CSS manifest as seed data to merge into Webpack manifest.json
+ */
+function createManifest() {
+  const manifest = glob.sync(`${DEST}/*.css`).reduce((acc, file) => {
+    const { original, fingerprinted } = fingerprint(file)
+    const { publicPath } = baseConfig.output
+    return {
+      ...acc,
+      [original]: publicPath + fingerprinted,
+    }
+  }, {})
+  return manifest
+}
+
+exports.getCSSManifest = () => {
+  try {
+    clean()
+    compile()
+    const manifest = createManifest()
+    console.log(chalk.green(`[Ervell compileCSS] Complete.`))
+    return manifest
+  } catch (error) {
+    console.error(chalk.red('[Ervell compileCSS] Error:', error))
+    process.exit(1)
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3686,11 +3686,6 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
 
-async@^0.9.0:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
-  integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
-
 async@^1.4.0, async@^1.5.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -3736,6 +3731,14 @@ await-to-js@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/await-to-js/-/await-to-js-2.1.1.tgz#c2093cd5a386f2bb945d79b292817bbc3f41b31b"
   integrity sha512-CHBC6gQGCIzjZ09tJ+XmpQoZOn4GdWePB4qUweCaKNJ0D3f115YdhmYVTZ4rMVpiJ3cFzZcTYK1VMYEICV4YXw==
+
+aws-sdk@~2.0.31:
+  version "2.0.31"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.0.31.tgz#e72cf1fdc69015bd9fd2bdf3d3b88c16507d268e"
+  integrity sha1-5yzx/caQFb2f0r3z07iMFlB9Jo4=
+  dependencies:
+    xml2js "0.2.6"
+    xmlbuilder "0.4.2"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -4730,18 +4733,6 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
-bucket-assets@aredotna/bucket-assets.git#d253febf7c658673c036afc85d034572011135e4:
-  version "1.0.2"
-  resolved "https://codeload.github.com/aredotna/bucket-assets/tar.gz/d253febf7c658673c036afc85d034572011135e4"
-  dependencies:
-    async "^0.9.0"
-    commander "^2.8.1"
-    glob "^5.0.5"
-    knox caremerge/knox.git#b1e031c209b3c17cab622a458e87728c1ee88cbd
-    mime "^1.3.4"
-    superagent "^1.2.0"
-    underscore "^1.8.3"
-
 buffer-from@^1.0.0, buffer-from@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
@@ -5622,7 +5613,7 @@ compare-versions@^3.1.0:
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.3.0.tgz#af93ea705a96943f622ab309578b9b90586f39c3"
   integrity sha512-MAAAIOdi2s4Gl6rZ76PNcUa9IOYB+5ICdT41o5uMRf09aEu/F9RK+qhe8RjXNPwcTjGV7KU7h2P/fljThFVqyQ==
 
-component-emitter@^1.2.0, component-emitter@^1.2.1, component-emitter@~1.2.0:
+component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
   integrity sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=
@@ -5810,11 +5801,6 @@ cookie@0.3.1, cookie@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
-
-cookiejar@2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.0.6.tgz#0abf356ad00d1c5a219d88d44518046dd026acfe"
-  integrity sha1-Cr81atANHFohnYjURRgEbdAmrP4=
 
 cookiejar@^2.1.0:
   version "2.1.1"
@@ -6293,19 +6279,19 @@ debug@*, debug@3.1.0, debug@=3.1.0, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@2, debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
 debug@2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   integrity sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=
   dependencies:
     ms "0.7.1"
+
+debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.8, debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
 
 debug@^3.2.5, debug@^3.2.6:
   version "3.2.6"
@@ -7555,11 +7541,6 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.0.tgz#5a474353b9f3353ddd8176dfd37b91c83a46f1d4"
-  integrity sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=
-
 extend@^3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -7746,7 +7727,7 @@ fbjs@^1.0.0:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
-fd-slicer@~1.0.1:
+fd-slicer@~1.0.0, fd-slicer@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
   integrity sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=
@@ -7926,6 +7907,11 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+findit2@~2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/findit2/-/findit2-2.2.3.tgz#58a466697df8a6205cdfdbf395536b8bd777a5f6"
+  integrity sha1-WKRmaX34piBc39vzlVNri9d3pfY=
+
 flat-cache@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.3.0.tgz#d3030b32b38154f4e3b7e9c709f490f7ef97c481"
@@ -8047,15 +8033,6 @@ fork-ts-checker-webpack-plugin@^0.4.10:
     resolve "^1.5.0"
     tapable "^1.0.0"
 
-form-data@1.0.0-rc3:
-  version "1.0.0-rc3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-1.0.0-rc3.tgz#d35bc62e7fbc2937ae78f948aaa0d38d90607577"
-  integrity sha1-01vGLn+8KTeuePlIqqDTjZBgdXc=
-  dependencies:
-    async "^1.4.0"
-    combined-stream "^1.0.5"
-    mime-types "^2.1.3"
-
 form-data@^2.3.1, form-data@~2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
@@ -8090,11 +8067,6 @@ formidable@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
   integrity sha1-lriIb3w8NQi5Mta9cMTTqI818ak=
-
-formidable@~1.0.14:
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.0.17.tgz#ef5491490f9433b705faa77249c99029ae348559"
-  integrity sha1-71SRSQ+UM7cF+qdyScmQKa40hVk=
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -8440,17 +8412,6 @@ glob@7.1.3, glob@^7.0.5, glob@^7.1.3, glob@~7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^5.0.5:
-  version "5.0.15"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
-  integrity sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 global-dirs@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/global-dirs/-/global-dirs-0.1.1.tgz#b319c0dd4607f353f3be9cca4c72fc148c49f445"
@@ -8626,6 +8587,13 @@ graceful-fs@^4.1.15, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
+
+graceful-fs@~3.0.5:
+  version "3.0.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-3.0.11.tgz#7613c778a1afea62f25c630a086d7f3acbbdd818"
+  integrity sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=
+  dependencies:
+    natives "^1.1.0"
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
@@ -10755,16 +10723,6 @@ kleur@^2.0.1:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-2.0.1.tgz#7cc64b0d188d0dcbc98bdcdfdda2cc10619ddce8"
   integrity sha512-Zq/jyANIJ2uX8UZjWlqLwbyhcxSXJtT/Y89lClyeZd3l++3ztL1I5SSCYrbcbwSunTjC88N3WuMk0kRDQD6gzA==
 
-knox@caremerge/knox.git#b1e031c209b3c17cab622a458e87728c1ee88cbd:
-  version "0.9.2"
-  resolved "https://codeload.github.com/caremerge/knox/tar.gz/b1e031c209b3c17cab622a458e87728c1ee88cbd"
-  dependencies:
-    debug "^2.2.0"
-    mime "1.4.0"
-    once "^1.3.0"
-    stream-counter "^1.0.0"
-    xml2js "^0.4.4"
-
 latest-version@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-3.1.0.tgz#a205383fea322b33b5ae3b18abee0dc2f356ee15"
@@ -11114,7 +11072,7 @@ lodash.unescape@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@4.17.11, lodash@^4.17.11, lodash@~4.17.10:
+lodash@4.17.11, "lodash@>=3.5 <5", lodash@^4.17.11, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -11463,7 +11421,7 @@ merge@^1.2.0:
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
   integrity sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=
 
-methods@^1.1.1, methods@^1.1.2, methods@~1.1.1, methods@~1.1.2:
+methods@^1.1.1, methods@^1.1.2, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -11536,7 +11494,7 @@ mime-types@^2.1.12, mime-types@~2.1.7:
   dependencies:
     mime-db "~1.36.0"
 
-mime-types@^2.1.3, mime-types@~2.1.15, mime-types@~2.1.17:
+mime-types@~2.1.15, mime-types@~2.1.17:
   version "2.1.17"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   integrity sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=
@@ -11550,22 +11508,12 @@ mime-types@~2.1.18:
   dependencies:
     mime-db "~1.33.0"
 
-mime@1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
-  integrity sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=
-
-mime@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.0.tgz#69e9e0db51d44f2a3b56e48b7817d7d137f1a343"
-  integrity sha512-n9ChLv77+QQEapYz8lV+rIZAW3HhAPW2CXnzb1GN5uMkuczshwvkW7XPsbzU0ZQN3sP47Er2KVkp2p3KyqZKSQ==
-
 mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
 
-mime@^1.3.4, mime@^1.4.1:
+mime@^1.4.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
@@ -11574,6 +11522,11 @@ mime@^2.0.3, mime@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
   integrity sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==
+
+mime@~1.2.11:
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.2.11.tgz#58203eed86e3a5ef17aed2b7d9ebd47f0a60dd10"
+  integrity sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -11619,7 +11572,7 @@ minimatch@0.3:
     lru-cache "2"
     sigmund "~1.0.0"
 
-"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
+minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -11886,6 +11839,11 @@ native-promise-only@0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
   integrity sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=
+
+natives@^1.1.0:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/natives/-/natives-1.1.6.tgz#a603b4a498ab77173612b9ea1acdec4d980f00bb"
+  integrity sha512-6+TDFewD4yxY14ptjKaS63GVdtKiES1pTPyxn9Jb0rBqPMZ7VcCiooEhPNsr+mqHtMGxa/5c/HhcC4uPEUw/nA==
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -13546,11 +13504,6 @@ qlimit@^0.1.1:
   dependencies:
     q "^1.0.0"
 
-qs@2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-2.3.3.tgz#e9e85adbe75da0bbe4c8e0476a086290f863b404"
-  integrity sha1-6eha2+ddoLvkyOBHaghikPhjtAQ=
-
 qs@6.5.1, qs@^6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
@@ -14140,16 +14093,6 @@ read-pkg@^4.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@1.0.27-1:
-  version "1.0.27-1"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.27-1.tgz#6b67983c20357cefd07f0165001a16d710d91078"
-  integrity sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
 readable-stream@1.1.x:
   version "1.1.14"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
@@ -14316,11 +14259,6 @@ redis@*:
     double-ended-queue "^2.1.0-0"
     redis-commands "^1.2.0"
     redis-parser "^2.6.0"
-
-reduce-component@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/reduce-component/-/reduce-component-1.0.1.tgz#e0c93542c574521bea13df0f9488ed82ab77c5da"
-  integrity sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo=
 
 reflect.ownkeys@^0.2.0:
   version "0.2.0"
@@ -14811,7 +14749,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@~2.2.6:
+rimraf@~2.2.6, rimraf@~2.2.8:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
   integrity sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=
@@ -14891,6 +14829,21 @@ rxjs@^6.3.3, rxjs@^6.4.0:
   dependencies:
     tslib "^1.9.0"
 
+s3@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/s3/-/s3-4.4.0.tgz#56a4f775515a7b6b9c8e5c6b1ab51f9037669f1f"
+  integrity sha1-VqT3dVFae2ucjlxrGrUfkDdmnx8=
+  dependencies:
+    aws-sdk "~2.0.31"
+    fd-slicer "~1.0.0"
+    findit2 "~2.2.3"
+    graceful-fs "~3.0.5"
+    mime "~1.2.11"
+    mkdirp "~0.5.0"
+    pend "~1.2.0"
+    rimraf "~2.2.8"
+    streamsink "~1.2.0"
+
 safe-buffer@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -14939,12 +14892,17 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.2.3"
 
+sax@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-0.4.2.tgz#39f3b601733d6bec97105b242a2a40fd6978ac3c"
+  integrity sha1-OfO2AXM9a+yXEFskKipA/Wl4rDw=
+
 sax@0.5.x:
   version "0.5.8"
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
   integrity sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=
 
-sax@>=0.6.0, sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
+sax@^1.2.4, sax@~1.2.1, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -15612,11 +15570,6 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
-stream-counter@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/stream-counter/-/stream-counter-1.0.0.tgz#91cf2569ce4dc5061febcd7acb26394a5a114751"
-  integrity sha1-kc8lac5NxQYf6816yyY5SloRR1E=
-
 stream-each@^1.1.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/stream-each/-/stream-each-1.2.2.tgz#8e8c463f91da8991778765873fe4d960d8f616bd"
@@ -15645,6 +15598,11 @@ streamsearch@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
   integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
+
+streamsink@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/streamsink/-/streamsink-1.2.0.tgz#efafee9f1e22d3591ed7de3dcaa95c3f5e79f73c"
+  integrity sha1-76/unx4i01ke1949yqlcP1559zw=
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -15909,23 +15867,6 @@ superagent@*, superagent@^3.6.0:
     mime "^1.4.1"
     qs "^6.5.1"
     readable-stream "^2.0.5"
-
-superagent@^1.2.0:
-  version "1.8.5"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-1.8.5.tgz#1c0ddc3af30e80eb84ebc05cb2122da8fe940b55"
-  integrity sha1-HA3cOvMOgOuE68BcshItqP6UC1U=
-  dependencies:
-    component-emitter "~1.2.0"
-    cookiejar "2.0.6"
-    debug "2"
-    extend "3.0.0"
-    form-data "1.0.0-rc3"
-    formidable "~1.0.14"
-    methods "~1.1.1"
-    mime "1.3.4"
-    qs "2.3.3"
-    readable-stream "1.0.27-1"
-    reduce-component "1.0.1"
 
 supports-color@1.2.0:
   version "1.2.0"
@@ -16592,7 +16533,7 @@ underscore.string@*:
     sprintf-js "^1.0.3"
     util-deprecate "^1.0.2"
 
-underscore@*, underscore@>=1.8.3, underscore@^1.8.3:
+underscore@*, underscore@>=1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
   integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
@@ -17153,6 +17094,15 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
+webpack-manifest-plugin@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/webpack-manifest-plugin/-/webpack-manifest-plugin-2.0.4.tgz#e4ca2999b09557716b8ba4475fb79fab5986f0cd"
+  integrity sha512-nejhOHexXDBKQOj/5v5IZSfCeTO3x1Dt1RZEcGfBSul891X/eLIcIVH31gwxPDdsi2Z8LKKFGpM4w9+oTBOSCg==
+  dependencies:
+    fs-extra "^7.0.0"
+    lodash ">=3.5 <5"
+    tapable "^1.0.0"
+
 webpack-merge@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.1.tgz#5e923cf802ea2ace4fd5af1d3247368a633489b4"
@@ -17466,18 +17416,17 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xml2js@^0.4.4:
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
-  integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==
+xml2js@0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.2.6.tgz#d209c4e4dda1fc9c452141ef41c077f5adfdf6c4"
+  integrity sha1-0gnE5N2h/JxFIUHvQcB39a399sQ=
   dependencies:
-    sax ">=0.6.0"
-    xmlbuilder "~9.0.1"
+    sax "0.4.2"
 
-xmlbuilder@~9.0.1:
-  version "9.0.4"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.4.tgz#519cb4ca686d005a8420d3496f3f0caeecca580f"
-  integrity sha1-UZy0ymhtAFqEINNJbz8MruzKWA8=
+xmlbuilder@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-0.4.2.tgz#1776d65f3fdbad470a08d8604cdeb1c4e540ff83"
+  integrity sha1-F3bWXz/brUcKCNhgTN6xxOVA/4M=
 
 xmlhttprequest@^1.8.0:
   version "1.8.0"


### PR DESCRIPTION
This PR removes `bucket-assets` in favor of Webpack and a local S3 upload script.

#### Overview: 

1) Replaced un-cacheable bucket-asset fingerprints with consistent hashes from webpack (hash only changes when the content inside changes, and webpack will track that)
1) This gives us source maps, since the hash from webpack matches the hashed source-map filename, also generated by webpack (rather than an external lib)
1) Replaced bucket-assets upload functionality with a local script, `scripts/uploadToS3.js`
1) Added a script to compile / hash CSS, which will change per build (like it did before). This doesn't go through Webpack because the code is too old and it would be hell to fix; it's mostly irrelevant as the app is now largely styled-components. The hashes get merged into webpacks manifest as a seed
1) Added a new middleware helper to return manifest assets
1) `ASSET_MANIFEST` env var can be removed from local envs and Heroku

To run / boot a full prod build: 
```
NODE_ENV=production yarn build && yarn build:server && yarn upload-to-s3 && yarn start:prod
```

(If needed, append `dotenv_config_path=./.env.production` to the script up above, but make sure that `NODE_ENV=production` is set in `.env` file.) 

To test assets running locally, comment out `CDN_URL` in `.env` file. 