### PR TITLE
Fix outbound links in Lightbox description

### DIFF
--- a/src/v2/components/BlockLightbox/components/BlockLightboxMetadataPane/index.js
+++ b/src/v2/components/BlockLightbox/components/BlockLightboxMetadataPane/index.js
@@ -109,9 +109,16 @@ export default class BlockLightboxMetadataPane extends PureComponent {
             breakWord
             boldLinks
             hoverLinks={{ color: 'black' }}
-            onClick={
-              block.can.manage ? this.openManageFor('description') : undefined
-            }
+            onClick={event => {
+              // If clicking an A tag in the description don't open edit box and
+              // instead defer to outbound link.
+              if (event.target.nodeName === 'A') {
+                return
+              }
+              if (block.can.manage) {
+                return this.openManageFor('description')(event)
+              }
+            }}
           />
         )}
 


### PR DESCRIPTION
Noticed that description links in the new lightbox don't click out anymore and instead trigger the edit modal, which is slightly less useful. This checks to to see if the underlying element is an `A` and then catches it, deferring to the outbound description link behavior.

#### Before: 

![before](https://user-images.githubusercontent.com/236943/56859955-481d0780-6946-11e9-914c-55e1db42b7da.gif)

#### After: 

![after](https://user-images.githubusercontent.com/236943/56859999-8286a480-6946-11e9-9e87-c419a87fa88b.gif)


