### PR TITLE
Responsive fix

### DIFF
--- a/src/v2/components/ProfileChannelIndex/index.js
+++ b/src/v2/components/ProfileChannelIndex/index.js
@@ -4,6 +4,7 @@ import { Query } from 'react-apollo'
 import styled from 'styled-components'
 
 import constants from 'v2/styles/constants'
+import { divide } from 'v2/styles/functions'
 
 import profileChannelIndexQuery from 'v2/components/ProfileChannelIndex/queries/profileChannelIndex'
 
@@ -25,6 +26,7 @@ const Columns = styled.div`
 
   ${constants.media.small`
     column-count: 1;
+    padding: 0 ${divide(constants.doubleBlockGutter, 2)};
   `}
 `
 

--- a/src/v2/components/UI/Constrain/index.js
+++ b/src/v2/components/UI/Constrain/index.js
@@ -8,7 +8,7 @@ import Box from 'v2/components/UI/Box'
 const BREAKPOINTS = new Array(8)
   .fill(undefined)
   .map((_, i) => {
-    const maxWidth = multiply(constants.blockAndGutter, i)
+    const maxWidth = multiply(constants.blockAndGutter, i + 1)
     const minWidth = add(constants.legacyUnit, maxWidth)
     return `@media (min-width: ${minWidth}) { max-width: ${maxWidth}; }`
   })


### PR DESCRIPTION
Closes #2024 

Before:
<img width="315" alt="Screenshot 2019-05-14 23 22 15" src="https://user-images.githubusercontent.com/821469/57746815-e1675000-76a0-11e9-93bc-112770c78c64.png">

After:
<img width="317" alt="Screenshot 2019-05-14 23 19 27" src="https://user-images.githubusercontent.com/821469/57746812-e0ceb980-76a0-11e9-94f8-5091c803691c.png">
<img width="318" alt="Screenshot 2019-05-14 23 32 37" src="https://user-images.githubusercontent.com/821469/57746814-e0ceb980-76a0-11e9-8b98-1c568bf0447b.png">
