### PR TITLE
Add default link styles

### DIFF
--- a/src/v2/components/UI/Layouts/BlankLayout/components/BaseStyles/index.js
+++ b/src/v2/components/UI/Layouts/BlankLayout/components/BaseStyles/index.js
@@ -7,6 +7,11 @@ export default createGlobalStyle`
     -webkit-font-smoothing: antialiased;
   }
 
+  a {
+    text-decoration: none;
+    color: inherit;
+  }
+  
   a:focus {
     outline: 0;
   }


### PR DESCRIPTION
Noticed a link underline sneaking in some places:

![Screen Shot 2019-06-22 at 1 13 16 PM](https://user-images.githubusercontent.com/821469/59966813-815d9800-94ef-11e9-9dff-48c6bb24d2ea.png)

![Screenshot 2019-06-22 13 13 07](https://user-images.githubusercontent.com/821469/59966815-86bae280-94ef-11e9-8989-93004751c716.png)
