### PR TITLE
Fix cursor on Delete Channel button hover

### DIFF
--- a/src/v2/components/ManageChannel/components/DeleteChannel/index.js
+++ b/src/v2/components/ManageChannel/components/DeleteChannel/index.js
@@ -54,7 +54,12 @@ class DeleteChannel extends Component {
     return (
       <div>
         <Text f={2} fontWeight="bold" color="state.alert">
-          <a role="button" tabIndex={0} onClick={this.pendDeleteChannel}>
+          <a
+            role="button"
+            tabIndex={0}
+            onClick={this.pendDeleteChannel}
+            style={{ cursor: 'pointer' }}
+          >
             Delete channel
           </a>
         </Text>


### PR DESCRIPTION
Since the `a` tag doesn't have an `href` it needed extra styling. 