### PR TITLE
Fix scrolling issue on iOS 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "bluebird": "^3.5.1",
     "bluebird-q": "^2.1.1",
     "body-parser": "*",
-    "body-scroll-lock": "^2.6.1",
     "cheerio": "^0.22.0",
     "chroma-js": "^1.4.0",
     "coffee-loader": "^0.9.0",

--- a/src/v2/components/UI/Modal/Portal.js
+++ b/src/v2/components/UI/Modal/Portal.js
@@ -1,7 +1,6 @@
 import React, { PureComponent } from 'react'
 import ReactDOM from 'react-dom'
 import PropTypes from 'prop-types'
-import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock'
 
 import ModalComponent from 'v2/components/UI/Modal/Modal'
 
@@ -17,12 +16,12 @@ export default class Modal extends PureComponent {
 
   componentDidMount() {
     document.body.appendChild(this.el)
-    disableBodyScroll(this.el)
+    document.body.style.overflow = 'hidden'
   }
 
   componentWillUnmount() {
     this.el.parentNode.removeChild(this.el)
-    clearAllBodyScrollLocks()
+    document.body.style.overflow = 'auto'
   }
 
   ModalComponent = ModalComponent

--- a/src/v2/components/UI/Modal/index.js
+++ b/src/v2/components/UI/Modal/index.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock'
 
 import { wrapWithProviders, initClientSideApolloClient } from 'v2/apollo'
 import mount from 'v2/util/mount'
@@ -31,9 +30,8 @@ export default class Modal {
     )
 
     const App = boot(ModalApp, props)
-
+    document.body.style.overflow = 'hidden'
     mount(App, this.el)
-    disableBodyScroll(this.el)
   }
 
   close = (...args) => {
@@ -43,6 +41,6 @@ export default class Modal {
 
     unmount(this.el)
     this.el.parentNode.removeChild(this.el)
-    clearAllBodyScrollLocks()
+    document.body.style.overflow = 'auto'
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4976,11 +4976,6 @@ body-parser@1.18.3:
     raw-body "2.3.3"
     type-is "~1.6.16"
 
-body-scroll-lock@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/body-scroll-lock/-/body-scroll-lock-2.6.1.tgz#3782ff37404886faaee366968ceee40c3964d8f2"
-  integrity sha512-fsDsq10+BJrk/+eGADqxspyZpGiKSh3dK8ByE6KuDK0REmPB99U05p1t9xVTAM9J6j9PJGm6W/W+HsCPnOFj+Q==
-
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"


### PR DESCRIPTION
As reported in Slack, and confirmed in testing, scroll for the Lightbox is completely broken in iOS 13. It seems that there have also been mixed reports in `body-scroll-lock` (https://github.com/willmcpo/body-scroll-lock/issues/102#issuecomment-482599456).

I've confirmed that this does the trick both on iOS, Safari, Chrome and Firefox.