### PR TITLE
Add cursor pointer on arrow hover

### DIFF
--- a/src/v2/components/ModalBlockLightbox/components/ModalBlockLightboxNavigation/index.js
+++ b/src/v2/components/ModalBlockLightbox/components/ModalBlockLightboxNavigation/index.js
@@ -40,6 +40,7 @@ const Prev = styled(Link).attrs({
 
     svg {
       fill: black;
+      cursor: pointer;
     }
   }
 `


### PR DESCRIPTION
Another silly small one -- adds a mouse cursor pointer when hovering (only) over the SVG arrow.

<img width="148" alt="Screen Shot 2020-01-09 at 11 51 01 PM" src="https://user-images.githubusercontent.com/236943/72135344-195f8980-333b-11ea-9df2-04c226fcb277.png">
