### PR TITLE
[Feature] Add DarkMode toggle to User Settings

### DIFF
--- a/src/v2/components/UI/Layouts/BlankLayout/components/LegacyDarkTheme/index.js
+++ b/src/v2/components/UI/Layouts/BlankLayout/components/LegacyDarkTheme/index.js
@@ -3,10 +3,10 @@
 import { createGlobalStyle } from 'styled-components'
 import Cookies from 'cookies-js'
 
-export const toggle = () => {
+export const toggle = mode => {
   const { theme } = document.documentElement.dataset
   const nextTheme = { dark: 'default', default: 'dark' }[theme]
-  document.documentElement.dataset.theme = nextTheme
+  document.documentElement.dataset.theme = mode || nextTheme
   const cookieFlag = { dark: '1', default: '0' }[nextTheme]
   Cookies.set('is-inverted', cookieFlag)
 }

--- a/src/v2/components/UserSettings/index.tsx
+++ b/src/v2/components/UserSettings/index.tsx
@@ -21,6 +21,7 @@ import Text from 'v2/components/UI/Text'
 import RadioOptions from 'v2/components/UI/RadioOptions'
 import Pulldown from 'v2/components/UI/Pulldown'
 import HorizontalRule from 'v2/components/UI/HorizontalRule'
+import { toggle as toggleOrSetTheme } from 'v2/components/UI/Layouts/BlankLayout/components/LegacyDarkTheme'
 
 import mapErrors from 'v2/util/mapErrors'
 
@@ -480,6 +481,47 @@ const UserSettings: React.FC<UserSettingsProps> = ({ me, updateAccount }) => {
                   </Field>
                 </>
               )}
+
+              <ContextDivider />
+
+              <Field
+                name="darkmode"
+                initialValue={document.documentElement.dataset.theme === 'dark'}
+              >
+                {props => {
+                  return (
+                    <>
+                      <InputContainer mt={6} mb={5}>
+                        <Label>Dark mode</Label>
+
+                        <RadioOptions
+                          value={props.input.value}
+                          onSelect={value => {
+                            const theme = value === true ? 'dark' : 'default'
+                            toggleOrSetTheme(theme)
+                          }}
+                        >
+                          <RadioOptions.Option value={true}>
+                            {({ selected }) => (
+                              <Text f={4} mb={3} selected={selected}>
+                                Enable
+                              </Text>
+                            )}
+                          </RadioOptions.Option>
+                          <RadioOptions.Option value={false}>
+                            {({ selected }) => (
+                              <Text f={4} mb={3} selected={selected}>
+                                Disable
+                              </Text>
+                            )}
+                          </RadioOptions.Option>
+                        </RadioOptions>
+                      </InputContainer>
+                    </>
+                  )
+                }}
+              </Field>
+
               <Box mt={8} pt={6}>
                 {submitSucceeded && (
                   <Alert bg="state.premium" color="white" mb={6}>


### PR DESCRIPTION
Adds the ability to explicitly set dark mode via the user's settings page making things a bit more discoverable. 

Not sure how to [update the docs](https://support.are.na/help/is-there-a-dark-mode), though, which only mention the key combo. 

![darkmode](https://user-images.githubusercontent.com/236943/73126582-6e211800-3f69-11ea-97ff-a386095e5d41.gif)

