### PR TITLE
[Feature] Add `/` hotkey to focus global search

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,9 @@
     "**/node_modules": true,
     "**/public": true
   },
-  "editor.rulers": [80],
+  "editor.rulers": [
+    80
+  ],
   "editor.tabSize": 2,
   "editor.formatOnSave": true,
   "eslint.validate": [
@@ -25,5 +27,5 @@
   "eslint.enable": true,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
-  }
+  },
 }

--- a/src/v2/components/TopBar/components/PrimarySearch/index.js
+++ b/src/v2/components/TopBar/components/PrimarySearch/index.js
@@ -106,6 +106,7 @@ export default class PrimarySearch extends PureComponent {
         {mode === 'resting' && <HomeLink />}
 
         <SearchInput
+          globallyFocusOnKey="/"
           tabIndex={1}
           flex="1"
           py={6}

--- a/src/v2/components/UI/SearchInput/index.tsx
+++ b/src/v2/components/UI/SearchInput/index.tsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react'
 import styled from 'styled-components'
 import { isEmpty, debounce, pick, omit } from 'underscore'
+import Mousetrap from 'mousetrap'
 
 import compactObject from 'v2/util/compactObject'
 
@@ -29,22 +30,23 @@ const Icon = styled.div`
 `
 
 interface IconMap {
-  resting: string
+  active: string
   focus: string
   hover: string
-  active: string
+  resting: string
 }
 
 interface Props extends BoxProps {
-  query?: string
-  onFocus?: () => any
-  onBlur?: () => any
-  onQueryChange?: (props: any) => any
-  onDebouncedQueryChange?: (props: any) => any
   debounceWait?: number
   forwardedRef?: any
+  globallyFocusOnKey?: string
   iconMap?: IconMap
+  onBlur?: () => any
+  onDebouncedQueryChange?: (props: any) => any
+  onFocus?: () => any
+  onQueryChange?: (props: any) => any
   placeholder?: string
+  query?: string
 }
 
 interface State {
@@ -88,6 +90,14 @@ class SearchInput extends PureComponent<Props, State> {
     }
   }
 
+  componentDidMount() {
+    this.maybeAttachGlobalFocusKeyListener()
+  }
+
+  componentWillUnmount() {
+    Mousetrap.unbind([this.props.globallyFocusOnKey])
+  }
+
   componentWillReceiveProps(nextProps) {
     if (isEmpty(nextProps.query) && !isEmpty(this.state.query)) {
       this.resetState()
@@ -98,6 +108,19 @@ class SearchInput extends PureComponent<Props, State> {
     this.setState({ query: '', mode: 'focus' })
     this.input.value = ''
     this.input.focus()
+  }
+
+  maybeAttachGlobalFocusKeyListener = () => {
+    const { globallyFocusOnKey } = this.props
+
+    if (globallyFocusOnKey) {
+      Mousetrap.bind(globallyFocusOnKey, event => {
+        event.preventDefault()
+        this.handleFocus()
+        this.input.focus()
+        this.input.value = ''
+      })
+    }
   }
 
   handleMouseEnter = () => {

--- a/src/v2/util/globalKeyboardShortcuts.js
+++ b/src/v2/util/globalKeyboardShortcuts.js
@@ -4,6 +4,17 @@ import { toggle as toggleDarkTheme } from 'v2/components/UI/Layouts/BlankLayout/
 
 export const bind = () => {
   Mousetrap.bind('shift+ctrl+i', toggleDarkTheme)
+
+  /**
+   * Additional global keybinding (`/`) is available for focusing search, and
+   * is bound within componentDidMount since there's currently no easy way to
+   * distantly communicate with mounted component instances.
+   *
+   * TODO: Can this shortcuts file be deleted since dark mode toggle is now
+   * within settings?
+   *
+   * @see src/v2/components/UI/SearchInput/index.tsx
+   */
 }
 
 export const unbind = () => {


### PR DESCRIPTION
This adds a new mousetrap `/` hotkey so that it's easy to jump to global search without using a mouse. 