### PR TITLE
Fix NAN around cover image edit date

### DIFF
--- a/src/v2/components/BlockLightbox/components/BlockLightboxActions/index.tsx
+++ b/src/v2/components/BlockLightbox/components/BlockLightboxActions/index.tsx
@@ -46,7 +46,7 @@ const BlockLightboxActions: React.FC<BlockLightboxActionsProps> = ({
 
   return (
     <Container>
-      {showImageEditedDate && (
+      {!!showImageEditedDate && (
         <Text color="gray.regular" fontSize={1}>
           Cover image edited on {imageUpdatedAt}
         </Text>


### PR DESCRIPTION
Noticed this with MP3 blocks: 

<img width="218" alt="Screen Shot 2020-02-24 at 10 03 54 PM" src="https://user-images.githubusercontent.com/236943/75219516-d70ad400-5751-11ea-999c-13eda676989d.png">
