### PR TITLE
Connection can destroy

### DIFF
--- a/src/__generated__/ChannelContents.ts
+++ b/src/__generated__/ChannelContents.ts
@@ -32,10 +32,16 @@ export interface ChannelContents_initial_contents_Text_connection_user {
   name: string | null;
 }
 
+export interface ChannelContents_initial_contents_Text_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContents_initial_contents_Text_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContents_initial_contents_Text_connection_user | null;
+  can: ChannelContents_initial_contents_Text_connection_can | null;
 }
 
 export interface ChannelContents_initial_contents_Text_source {
@@ -83,10 +89,16 @@ export interface ChannelContents_initial_contents_Image_connection_user {
   name: string | null;
 }
 
+export interface ChannelContents_initial_contents_Image_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContents_initial_contents_Image_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContents_initial_contents_Image_connection_user | null;
+  can: ChannelContents_initial_contents_Image_connection_can | null;
 }
 
 export interface ChannelContents_initial_contents_Image_source {
@@ -135,10 +147,16 @@ export interface ChannelContents_initial_contents_Link_connection_user {
   name: string | null;
 }
 
+export interface ChannelContents_initial_contents_Link_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContents_initial_contents_Link_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContents_initial_contents_Link_connection_user | null;
+  can: ChannelContents_initial_contents_Link_connection_can | null;
 }
 
 export interface ChannelContents_initial_contents_Link_source {
@@ -187,10 +205,16 @@ export interface ChannelContents_initial_contents_Embed_connection_user {
   name: string | null;
 }
 
+export interface ChannelContents_initial_contents_Embed_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContents_initial_contents_Embed_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContents_initial_contents_Embed_connection_user | null;
+  can: ChannelContents_initial_contents_Embed_connection_can | null;
 }
 
 export interface ChannelContents_initial_contents_Embed_source {
@@ -238,10 +262,16 @@ export interface ChannelContents_initial_contents_Attachment_connection_user {
   name: string | null;
 }
 
+export interface ChannelContents_initial_contents_Attachment_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContents_initial_contents_Attachment_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContents_initial_contents_Attachment_connection_user | null;
+  can: ChannelContents_initial_contents_Attachment_connection_can | null;
 }
 
 export interface ChannelContents_initial_contents_Attachment_source {
@@ -290,10 +320,16 @@ export interface ChannelContents_initial_contents_PendingBlock_connection_user {
   name: string | null;
 }
 
+export interface ChannelContents_initial_contents_PendingBlock_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContents_initial_contents_PendingBlock_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContents_initial_contents_PendingBlock_connection_user | null;
+  can: ChannelContents_initial_contents_PendingBlock_connection_can | null;
 }
 
 export interface ChannelContents_initial_contents_PendingBlock_source {
@@ -340,10 +376,16 @@ export interface ChannelContents_initial_contents_Channel_connection_user {
   name: string | null;
 }
 
+export interface ChannelContents_initial_contents_Channel_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContents_initial_contents_Channel_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContents_initial_contents_Channel_connection_user | null;
+  can: ChannelContents_initial_contents_Channel_connection_can | null;
 }
 
 export interface ChannelContents_initial_contents_Channel_source {

--- a/src/__generated__/ChannelContentsConnectable.ts
+++ b/src/__generated__/ChannelContentsConnectable.ts
@@ -18,10 +18,16 @@ export interface ChannelContentsConnectable_Text_connection_user {
   name: string | null;
 }
 
+export interface ChannelContentsConnectable_Text_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsConnectable_Text_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsConnectable_Text_connection_user | null;
+  can: ChannelContentsConnectable_Text_connection_can | null;
 }
 
 export interface ChannelContentsConnectable_Text_source {
@@ -69,10 +75,16 @@ export interface ChannelContentsConnectable_Image_connection_user {
   name: string | null;
 }
 
+export interface ChannelContentsConnectable_Image_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsConnectable_Image_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsConnectable_Image_connection_user | null;
+  can: ChannelContentsConnectable_Image_connection_can | null;
 }
 
 export interface ChannelContentsConnectable_Image_source {
@@ -121,10 +133,16 @@ export interface ChannelContentsConnectable_Link_connection_user {
   name: string | null;
 }
 
+export interface ChannelContentsConnectable_Link_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsConnectable_Link_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsConnectable_Link_connection_user | null;
+  can: ChannelContentsConnectable_Link_connection_can | null;
 }
 
 export interface ChannelContentsConnectable_Link_source {
@@ -173,10 +191,16 @@ export interface ChannelContentsConnectable_Embed_connection_user {
   name: string | null;
 }
 
+export interface ChannelContentsConnectable_Embed_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsConnectable_Embed_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsConnectable_Embed_connection_user | null;
+  can: ChannelContentsConnectable_Embed_connection_can | null;
 }
 
 export interface ChannelContentsConnectable_Embed_source {
@@ -224,10 +248,16 @@ export interface ChannelContentsConnectable_Attachment_connection_user {
   name: string | null;
 }
 
+export interface ChannelContentsConnectable_Attachment_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsConnectable_Attachment_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsConnectable_Attachment_connection_user | null;
+  can: ChannelContentsConnectable_Attachment_connection_can | null;
 }
 
 export interface ChannelContentsConnectable_Attachment_source {
@@ -276,10 +306,16 @@ export interface ChannelContentsConnectable_PendingBlock_connection_user {
   name: string | null;
 }
 
+export interface ChannelContentsConnectable_PendingBlock_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsConnectable_PendingBlock_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsConnectable_PendingBlock_connection_user | null;
+  can: ChannelContentsConnectable_PendingBlock_connection_can | null;
 }
 
 export interface ChannelContentsConnectable_PendingBlock_source {
@@ -326,10 +362,16 @@ export interface ChannelContentsConnectable_Channel_connection_user {
   name: string | null;
 }
 
+export interface ChannelContentsConnectable_Channel_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsConnectable_Channel_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsConnectable_Channel_connection_user | null;
+  can: ChannelContentsConnectable_Channel_connection_can | null;
 }
 
 export interface ChannelContentsConnectable_Channel_source {

--- a/src/__generated__/ChannelContentsSet.ts
+++ b/src/__generated__/ChannelContentsSet.ts
@@ -20,10 +20,16 @@ export interface ChannelContentsSet_channel_contents_Text_connection_user {
   name: string | null;
 }
 
+export interface ChannelContentsSet_channel_contents_Text_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsSet_channel_contents_Text_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsSet_channel_contents_Text_connection_user | null;
+  can: ChannelContentsSet_channel_contents_Text_connection_can | null;
 }
 
 export interface ChannelContentsSet_channel_contents_Text_source {
@@ -71,10 +77,16 @@ export interface ChannelContentsSet_channel_contents_Image_connection_user {
   name: string | null;
 }
 
+export interface ChannelContentsSet_channel_contents_Image_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsSet_channel_contents_Image_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsSet_channel_contents_Image_connection_user | null;
+  can: ChannelContentsSet_channel_contents_Image_connection_can | null;
 }
 
 export interface ChannelContentsSet_channel_contents_Image_source {
@@ -123,10 +135,16 @@ export interface ChannelContentsSet_channel_contents_Link_connection_user {
   name: string | null;
 }
 
+export interface ChannelContentsSet_channel_contents_Link_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsSet_channel_contents_Link_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsSet_channel_contents_Link_connection_user | null;
+  can: ChannelContentsSet_channel_contents_Link_connection_can | null;
 }
 
 export interface ChannelContentsSet_channel_contents_Link_source {
@@ -175,10 +193,16 @@ export interface ChannelContentsSet_channel_contents_Embed_connection_user {
   name: string | null;
 }
 
+export interface ChannelContentsSet_channel_contents_Embed_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsSet_channel_contents_Embed_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsSet_channel_contents_Embed_connection_user | null;
+  can: ChannelContentsSet_channel_contents_Embed_connection_can | null;
 }
 
 export interface ChannelContentsSet_channel_contents_Embed_source {
@@ -226,10 +250,16 @@ export interface ChannelContentsSet_channel_contents_Attachment_connection_user 
   name: string | null;
 }
 
+export interface ChannelContentsSet_channel_contents_Attachment_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsSet_channel_contents_Attachment_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsSet_channel_contents_Attachment_connection_user | null;
+  can: ChannelContentsSet_channel_contents_Attachment_connection_can | null;
 }
 
 export interface ChannelContentsSet_channel_contents_Attachment_source {
@@ -278,10 +308,16 @@ export interface ChannelContentsSet_channel_contents_PendingBlock_connection_use
   name: string | null;
 }
 
+export interface ChannelContentsSet_channel_contents_PendingBlock_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsSet_channel_contents_PendingBlock_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsSet_channel_contents_PendingBlock_connection_user | null;
+  can: ChannelContentsSet_channel_contents_PendingBlock_connection_can | null;
 }
 
 export interface ChannelContentsSet_channel_contents_PendingBlock_source {
@@ -328,10 +364,16 @@ export interface ChannelContentsSet_channel_contents_Channel_connection_user {
   name: string | null;
 }
 
+export interface ChannelContentsSet_channel_contents_Channel_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsSet_channel_contents_Channel_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsSet_channel_contents_Channel_connection_user | null;
+  can: ChannelContentsSet_channel_contents_Channel_connection_can | null;
 }
 
 export interface ChannelContentsSet_channel_contents_Channel_source {

--- a/src/__generated__/ChannelContentsWithData.ts
+++ b/src/__generated__/ChannelContentsWithData.ts
@@ -32,10 +32,16 @@ export interface ChannelContentsWithData_channel_initial_contents_Text_connectio
   name: string | null;
 }
 
+export interface ChannelContentsWithData_channel_initial_contents_Text_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsWithData_channel_initial_contents_Text_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsWithData_channel_initial_contents_Text_connection_user | null;
+  can: ChannelContentsWithData_channel_initial_contents_Text_connection_can | null;
 }
 
 export interface ChannelContentsWithData_channel_initial_contents_Text_source {
@@ -83,10 +89,16 @@ export interface ChannelContentsWithData_channel_initial_contents_Image_connecti
   name: string | null;
 }
 
+export interface ChannelContentsWithData_channel_initial_contents_Image_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsWithData_channel_initial_contents_Image_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsWithData_channel_initial_contents_Image_connection_user | null;
+  can: ChannelContentsWithData_channel_initial_contents_Image_connection_can | null;
 }
 
 export interface ChannelContentsWithData_channel_initial_contents_Image_source {
@@ -135,10 +147,16 @@ export interface ChannelContentsWithData_channel_initial_contents_Link_connectio
   name: string | null;
 }
 
+export interface ChannelContentsWithData_channel_initial_contents_Link_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsWithData_channel_initial_contents_Link_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsWithData_channel_initial_contents_Link_connection_user | null;
+  can: ChannelContentsWithData_channel_initial_contents_Link_connection_can | null;
 }
 
 export interface ChannelContentsWithData_channel_initial_contents_Link_source {
@@ -187,10 +205,16 @@ export interface ChannelContentsWithData_channel_initial_contents_Embed_connecti
   name: string | null;
 }
 
+export interface ChannelContentsWithData_channel_initial_contents_Embed_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsWithData_channel_initial_contents_Embed_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsWithData_channel_initial_contents_Embed_connection_user | null;
+  can: ChannelContentsWithData_channel_initial_contents_Embed_connection_can | null;
 }
 
 export interface ChannelContentsWithData_channel_initial_contents_Embed_source {
@@ -238,10 +262,16 @@ export interface ChannelContentsWithData_channel_initial_contents_Attachment_con
   name: string | null;
 }
 
+export interface ChannelContentsWithData_channel_initial_contents_Attachment_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsWithData_channel_initial_contents_Attachment_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsWithData_channel_initial_contents_Attachment_connection_user | null;
+  can: ChannelContentsWithData_channel_initial_contents_Attachment_connection_can | null;
 }
 
 export interface ChannelContentsWithData_channel_initial_contents_Attachment_source {
@@ -290,10 +320,16 @@ export interface ChannelContentsWithData_channel_initial_contents_PendingBlock_c
   name: string | null;
 }
 
+export interface ChannelContentsWithData_channel_initial_contents_PendingBlock_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsWithData_channel_initial_contents_PendingBlock_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsWithData_channel_initial_contents_PendingBlock_connection_user | null;
+  can: ChannelContentsWithData_channel_initial_contents_PendingBlock_connection_can | null;
 }
 
 export interface ChannelContentsWithData_channel_initial_contents_PendingBlock_source {
@@ -340,10 +376,16 @@ export interface ChannelContentsWithData_channel_initial_contents_Channel_connec
   name: string | null;
 }
 
+export interface ChannelContentsWithData_channel_initial_contents_Channel_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface ChannelContentsWithData_channel_initial_contents_Channel_connection {
   __typename: "Connection";
   created_at: string | null;
   user: ChannelContentsWithData_channel_initial_contents_Channel_connection_user | null;
+  can: ChannelContentsWithData_channel_initial_contents_Channel_connection_can | null;
 }
 
 export interface ChannelContentsWithData_channel_initial_contents_Channel_source {

--- a/src/__generated__/ConnectableContextMenuConnectable.ts
+++ b/src/__generated__/ConnectableContextMenuConnectable.ts
@@ -12,6 +12,16 @@ export interface ConnectableContextMenuConnectable_Text_can {
   remove: boolean | null;
 }
 
+export interface ConnectableContextMenuConnectable_Text_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
+export interface ConnectableContextMenuConnectable_Text_connection {
+  __typename: "Connection";
+  can: ConnectableContextMenuConnectable_Text_connection_can | null;
+}
+
 export interface ConnectableContextMenuConnectable_Text_source {
   __typename: "ConnectableSource";
   url: string | null;
@@ -21,6 +31,11 @@ export interface ConnectableContextMenuConnectable_Text {
   __typename: "Text";
   id: number | null;
   can: ConnectableContextMenuConnectable_Text_can | null;
+  href: string | null;
+  /**
+   * Returns the outer channel if we are inside of one
+   */
+  connection: ConnectableContextMenuConnectable_Text_connection | null;
   source: ConnectableContextMenuConnectable_Text_source | null;
 }
 
@@ -28,6 +43,16 @@ export interface ConnectableContextMenuConnectable_Image_can {
   __typename: "BlockCan";
   mute: boolean | null;
   remove: boolean | null;
+}
+
+export interface ConnectableContextMenuConnectable_Image_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
+export interface ConnectableContextMenuConnectable_Image_connection {
+  __typename: "Connection";
+  can: ConnectableContextMenuConnectable_Image_connection_can | null;
 }
 
 export interface ConnectableContextMenuConnectable_Image_source {
@@ -39,6 +64,11 @@ export interface ConnectableContextMenuConnectable_Image {
   __typename: "Image";
   id: number | null;
   can: ConnectableContextMenuConnectable_Image_can | null;
+  href: string | null;
+  /**
+   * Returns the outer channel if we are inside of one
+   */
+  connection: ConnectableContextMenuConnectable_Image_connection | null;
   source: ConnectableContextMenuConnectable_Image_source | null;
   find_original_url: string | null;
 }
@@ -47,6 +77,16 @@ export interface ConnectableContextMenuConnectable_Link_can {
   __typename: "BlockCan";
   mute: boolean | null;
   remove: boolean | null;
+}
+
+export interface ConnectableContextMenuConnectable_Link_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
+export interface ConnectableContextMenuConnectable_Link_connection {
+  __typename: "Connection";
+  can: ConnectableContextMenuConnectable_Link_connection_can | null;
 }
 
 export interface ConnectableContextMenuConnectable_Link_source {
@@ -58,6 +98,11 @@ export interface ConnectableContextMenuConnectable_Link {
   __typename: "Link";
   id: number | null;
   can: ConnectableContextMenuConnectable_Link_can | null;
+  href: string | null;
+  /**
+   * Returns the outer channel if we are inside of one
+   */
+  connection: ConnectableContextMenuConnectable_Link_connection | null;
   source: ConnectableContextMenuConnectable_Link_source | null;
 }
 
@@ -65,6 +110,16 @@ export interface ConnectableContextMenuConnectable_Embed_can {
   __typename: "BlockCan";
   mute: boolean | null;
   remove: boolean | null;
+}
+
+export interface ConnectableContextMenuConnectable_Embed_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
+export interface ConnectableContextMenuConnectable_Embed_connection {
+  __typename: "Connection";
+  can: ConnectableContextMenuConnectable_Embed_connection_can | null;
 }
 
 export interface ConnectableContextMenuConnectable_Embed_source {
@@ -76,6 +131,11 @@ export interface ConnectableContextMenuConnectable_Embed {
   __typename: "Embed";
   id: number | null;
   can: ConnectableContextMenuConnectable_Embed_can | null;
+  href: string | null;
+  /**
+   * Returns the outer channel if we are inside of one
+   */
+  connection: ConnectableContextMenuConnectable_Embed_connection | null;
   source: ConnectableContextMenuConnectable_Embed_source | null;
 }
 
@@ -83,6 +143,16 @@ export interface ConnectableContextMenuConnectable_Attachment_can {
   __typename: "BlockCan";
   mute: boolean | null;
   remove: boolean | null;
+}
+
+export interface ConnectableContextMenuConnectable_Attachment_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
+export interface ConnectableContextMenuConnectable_Attachment_connection {
+  __typename: "Connection";
+  can: ConnectableContextMenuConnectable_Attachment_connection_can | null;
 }
 
 export interface ConnectableContextMenuConnectable_Attachment_source {
@@ -94,6 +164,11 @@ export interface ConnectableContextMenuConnectable_Attachment {
   __typename: "Attachment";
   id: number | null;
   can: ConnectableContextMenuConnectable_Attachment_can | null;
+  href: string | null;
+  /**
+   * Returns the outer channel if we are inside of one
+   */
+  connection: ConnectableContextMenuConnectable_Attachment_connection | null;
   source: ConnectableContextMenuConnectable_Attachment_source | null;
 }
 
@@ -103,10 +178,35 @@ export interface ConnectableContextMenuConnectable_PendingBlock_can {
   remove: boolean | null;
 }
 
+export interface ConnectableContextMenuConnectable_PendingBlock_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
+export interface ConnectableContextMenuConnectable_PendingBlock_connection {
+  __typename: "Connection";
+  can: ConnectableContextMenuConnectable_PendingBlock_connection_can | null;
+}
+
 export interface ConnectableContextMenuConnectable_PendingBlock {
   __typename: "PendingBlock";
   id: number | null;
   can: ConnectableContextMenuConnectable_PendingBlock_can | null;
+  href: string | null;
+  /**
+   * Returns the outer channel if we are inside of one
+   */
+  connection: ConnectableContextMenuConnectable_PendingBlock_connection | null;
+}
+
+export interface ConnectableContextMenuConnectable_Channel_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
+export interface ConnectableContextMenuConnectable_Channel_connection {
+  __typename: "Connection";
+  can: ConnectableContextMenuConnectable_Channel_connection_can | null;
 }
 
 export interface ConnectableContextMenuConnectable_Channel_can {
@@ -117,6 +217,11 @@ export interface ConnectableContextMenuConnectable_Channel_can {
 export interface ConnectableContextMenuConnectable_Channel {
   __typename: "Channel";
   id: number | null;
+  href: string | null;
+  /**
+   * Returns the outer channel if we are inside of one
+   */
+  connection: ConnectableContextMenuConnectable_Channel_connection | null;
   can: ConnectableContextMenuConnectable_Channel_can | null;
 }
 

--- a/src/__generated__/SharedChannelPage.ts
+++ b/src/__generated__/SharedChannelPage.ts
@@ -123,10 +123,16 @@ export interface SharedChannelPage_channel_initial_contents_Text_connection_user
   name: string | null;
 }
 
+export interface SharedChannelPage_channel_initial_contents_Text_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface SharedChannelPage_channel_initial_contents_Text_connection {
   __typename: "Connection";
   created_at: string | null;
   user: SharedChannelPage_channel_initial_contents_Text_connection_user | null;
+  can: SharedChannelPage_channel_initial_contents_Text_connection_can | null;
 }
 
 export interface SharedChannelPage_channel_initial_contents_Text_source {
@@ -174,10 +180,16 @@ export interface SharedChannelPage_channel_initial_contents_Image_connection_use
   name: string | null;
 }
 
+export interface SharedChannelPage_channel_initial_contents_Image_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface SharedChannelPage_channel_initial_contents_Image_connection {
   __typename: "Connection";
   created_at: string | null;
   user: SharedChannelPage_channel_initial_contents_Image_connection_user | null;
+  can: SharedChannelPage_channel_initial_contents_Image_connection_can | null;
 }
 
 export interface SharedChannelPage_channel_initial_contents_Image_source {
@@ -226,10 +238,16 @@ export interface SharedChannelPage_channel_initial_contents_Link_connection_user
   name: string | null;
 }
 
+export interface SharedChannelPage_channel_initial_contents_Link_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface SharedChannelPage_channel_initial_contents_Link_connection {
   __typename: "Connection";
   created_at: string | null;
   user: SharedChannelPage_channel_initial_contents_Link_connection_user | null;
+  can: SharedChannelPage_channel_initial_contents_Link_connection_can | null;
 }
 
 export interface SharedChannelPage_channel_initial_contents_Link_source {
@@ -278,10 +296,16 @@ export interface SharedChannelPage_channel_initial_contents_Embed_connection_use
   name: string | null;
 }
 
+export interface SharedChannelPage_channel_initial_contents_Embed_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface SharedChannelPage_channel_initial_contents_Embed_connection {
   __typename: "Connection";
   created_at: string | null;
   user: SharedChannelPage_channel_initial_contents_Embed_connection_user | null;
+  can: SharedChannelPage_channel_initial_contents_Embed_connection_can | null;
 }
 
 export interface SharedChannelPage_channel_initial_contents_Embed_source {
@@ -329,10 +353,16 @@ export interface SharedChannelPage_channel_initial_contents_Attachment_connectio
   name: string | null;
 }
 
+export interface SharedChannelPage_channel_initial_contents_Attachment_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface SharedChannelPage_channel_initial_contents_Attachment_connection {
   __typename: "Connection";
   created_at: string | null;
   user: SharedChannelPage_channel_initial_contents_Attachment_connection_user | null;
+  can: SharedChannelPage_channel_initial_contents_Attachment_connection_can | null;
 }
 
 export interface SharedChannelPage_channel_initial_contents_Attachment_source {
@@ -381,10 +411,16 @@ export interface SharedChannelPage_channel_initial_contents_PendingBlock_connect
   name: string | null;
 }
 
+export interface SharedChannelPage_channel_initial_contents_PendingBlock_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface SharedChannelPage_channel_initial_contents_PendingBlock_connection {
   __typename: "Connection";
   created_at: string | null;
   user: SharedChannelPage_channel_initial_contents_PendingBlock_connection_user | null;
+  can: SharedChannelPage_channel_initial_contents_PendingBlock_connection_can | null;
 }
 
 export interface SharedChannelPage_channel_initial_contents_PendingBlock_source {
@@ -431,10 +467,16 @@ export interface SharedChannelPage_channel_initial_contents_Channel_connection_u
   name: string | null;
 }
 
+export interface SharedChannelPage_channel_initial_contents_Channel_connection_can {
+  __typename: "ConnectionCan";
+  destroy: boolean | null;
+}
+
 export interface SharedChannelPage_channel_initial_contents_Channel_connection {
   __typename: "Connection";
   created_at: string | null;
   user: SharedChannelPage_channel_initial_contents_Channel_connection_user | null;
+  can: SharedChannelPage_channel_initial_contents_Channel_connection_can | null;
 }
 
 export interface SharedChannelPage_channel_initial_contents_Channel_source {

--- a/src/v2/components/ConnectableContextMenu/fragments/connectableContextMenu.ts
+++ b/src/v2/components/ConnectableContextMenu/fragments/connectableContextMenu.ts
@@ -23,6 +23,16 @@ export const connectableContextMenuConnectableFragment = gql`
         remove: manage
       }
     }
+
+    ... on ConnectableInterface {
+      href
+      connection {
+        can {
+          destroy
+        }
+      }
+    }
+
     ... on Channel {
       can {
         mute

--- a/src/v2/components/ConnectableContextMenu/index.tsx
+++ b/src/v2/components/ConnectableContextMenu/index.tsx
@@ -35,14 +35,19 @@ export const ConnectableContextMenu: React.FC<Props> = ({
     sourceUrl ||
     findOriginalUrl ||
     connectable.can.mute ||
-    channel.can.reorder_connections
+    channel.can.reorder_connections ||
+    connectable.connection.can.destroy
+
+  const canRemove =
+    channel.can.remove_connections ||
+    (connectable.__typename !== 'Channel' && connectable.can.remove) ||
+    connectable.connection.can.destroy
 
   if (!isDisplayable) return null
 
   return (
     <ContextMenu position="absolute" top={8} right={8} zIndex={1} {...rest}>
-      {(channel.can.remove_connections ||
-        (connectable.__typename !== 'Channel' && connectable.can.remove)) && (
+      {canRemove && (
         <ConnectableContextMenuRemoveConnection
           channelId={channel.id}
           connectableId={connectable.id}


### PR DESCRIPTION
This fixes a problem where: if I connect a block or channel (neither of which I own) to an open channel (which I also don't own) then I can't remove the connection (which I should be able to do).