### PR TITLE
Add white-space rule for the poets

### DIFF
--- a/src/v2/components/UI/SansSerifText/index.tsx
+++ b/src/v2/components/UI/SansSerifText/index.tsx
@@ -64,6 +64,15 @@ export const mixin = css`
 
   line-height: 1.6;
 
+  p {
+    white-space: pre-wrap;
+
+    // remove br's since we are doing pre-wrap now
+    br {
+      display none;
+    }
+  }
+
   p, li, ol {
     font-size: 1.05rem;
   }


### PR DESCRIPTION
Before:
![Screen Shot 2020-06-29 at 4 51 58 PM](https://user-images.githubusercontent.com/821469/86054882-f465ec80-ba28-11ea-9947-7f21cb8af04e.png)

After (accurate spacing):
![Screen Shot 2020-06-29 at 4 52 11 PM](https://user-images.githubusercontent.com/821469/86054893-fa5bcd80-ba28-11ea-8052-47b45f7ff0ff.png)

Before:
![Screen Shot 2020-06-29 at 4 55 47 PM](https://user-images.githubusercontent.com/821469/86055196-6b9b8080-ba29-11ea-850f-17f712653b05.png)

After:
![Screen Shot 2020-06-29 at 4 55 56 PM](https://user-images.githubusercontent.com/821469/86055199-6b9b8080-ba29-11ea-97cc-11863b1bca0a.png)
