### PR TITLE
Fix top bar on error page

### DIFF
--- a/src/__generated__/IsErrorPageQueryHook.ts
+++ b/src/__generated__/IsErrorPageQueryHook.ts
@@ -1,0 +1,16 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: IsErrorPageQueryHook
+// ====================================================
+
+export interface IsErrorPageQueryHook_sharify {
+  __typename: "ClientSharify";
+  isErrorPage: boolean | null;
+}
+
+export interface IsErrorPageQueryHook {
+  sharify: IsErrorPageQueryHook_sharify | null;
+}

--- a/src/apps/errors/index.js
+++ b/src/apps/errors/index.js
@@ -12,6 +12,8 @@ export default (err, req, res, _next) => {
   const status = err.status || 500
   const isVisible = NODE_ENV === 'development'
 
+  res.locals.sd.IS_ERROR = true
+
   const response = {
     code: status,
     message: isVisible ? err.message : 'Internal server error',

--- a/src/components/layout/client.coffee
+++ b/src/components/layout/client.coffee
@@ -20,7 +20,7 @@ initLoggedOutCTA = require '../logged_out_cta/index.coffee'
 initLightboxKeyboardShortcuts = require('./initLightboxKeyboardShortcuts')
 
 { mountWithApolloProvider } = require '../../v2/apollo/index'
-{ default: GlobalNavElements } = require '../../v2/components/GlobalNavElements/index'
+{ GlobalNavElementsWithRouter } = require '../../v2/components/GlobalNavElements/index'
 
 module.exports = ->
   setDeviceClasses()
@@ -68,7 +68,7 @@ setupViews = ->
 
   if ($topBar = $('.js-topbar')).length
     scheme = if sd.IS_GROUP_PAGE then 'GROUP' else 'DEFAULT'
-    mountWithApolloProvider(GlobalNavElements, { scheme: scheme }, $topBar)
+    mountWithApolloProvider(GlobalNavElementsWithRouter, { scheme: scheme }, $topBar)
 
 # TODO: Extract
 setupAjaxHeaders = ->

--- a/src/v2/apollo/localState/clientSchema.graphql
+++ b/src/v2/apollo/localState/clientSchema.graphql
@@ -45,5 +45,6 @@ type ClientSerializedMe {
 type ClientSharify {
   get(name: String): String
   IS_SPIDER: Boolean
+  IS_ERROR: Boolean
   THEME: String
 }

--- a/src/v2/components/GlobalNavElements/index.js
+++ b/src/v2/components/GlobalNavElements/index.js
@@ -10,6 +10,7 @@ import BottomBanner from 'v2/components/BottomBanner'
 import WithSerializedMe from 'v2/hocs/WithSerializedMe'
 
 import globalNavElementsQuery from 'v2/components/GlobalNavElements/queries/globalNavElements'
+import { BrowserRouter } from 'react-router-dom'
 
 // Includes
 // - TopBar (logged-in/out)
@@ -82,4 +83,14 @@ class GlobalNavElements extends PureComponent {
   }
 }
 
-export default WithSerializedMe(GlobalNavElements)
+const GlobalNavElementsWithSerializedMe = WithSerializedMe(GlobalNavElements)
+
+export default GlobalNavElementsWithSerializedMe
+
+export const GlobalNavElementsWithRouter = () => {
+  return (
+    <BrowserRouter>
+      <GlobalNavElementsWithSerializedMe />
+    </BrowserRouter>
+  )
+}

--- a/src/v2/components/TopBar/components/PrimarySearch/index.tsx
+++ b/src/v2/components/TopBar/components/PrimarySearch/index.tsx
@@ -9,6 +9,7 @@ import SearchInput from 'v2/components/UI/SearchInput'
 import PrimarySearchResults from 'v2/components/TopBar/components/PrimarySearch/components/PrimarySearchResults'
 
 import { overflowScrolling } from 'v2/styles/mixins'
+import useIsErrorPage from 'v2/hooks/useIsErrorPage'
 
 const Container = styled(Box)`
   position: relative;
@@ -24,6 +25,7 @@ const Results = styled(Box)`
 interface PrimarySearchProps {
   scheme: 'DEFAULT' | 'GROUP'
   history: any
+  isErrorPage: boolean
   flex?: number
 }
 
@@ -65,7 +67,7 @@ class PrimarySearch extends PureComponent<PrimarySearchProps> {
 
   handleKeyDown = ({ key }) => {
     const { cursor, href, query } = this.state
-    const { history } = this.props
+    const { history, isErrorPage } = this.props
 
     switch (key) {
       case 'Escape':
@@ -74,6 +76,12 @@ class PrimarySearch extends PureComponent<PrimarySearchProps> {
       case 'Enter':
         if (query === '') return
         this.setState({ query: '', debouncedQuery: '' })
+
+        if (isErrorPage) {
+          window.location.href = href
+          break
+        }
+
         history.push(href)
         break
       case 'ArrowDown':
@@ -157,12 +165,11 @@ const PrimarySearchContainer: React.FC<{
   scheme: 'DEFAULT' | 'GROUP'
   flex?: number
 }> = ({ ...props }) => {
-  try {
-    const history = useHistory()
-    return <PrimarySearch history={history} {...props} />
-  } catch {
-    return <PrimarySearch history={history} {...props} />
-  }
+  const history = useHistory()
+  const isErrorPage = useIsErrorPage()
+  return (
+    <PrimarySearch history={history} isErrorPage={isErrorPage} {...props} />
+  )
 }
 
 export default PrimarySearchContainer

--- a/src/v2/components/TopBar/components/PrimarySearch/index.tsx
+++ b/src/v2/components/TopBar/components/PrimarySearch/index.tsx
@@ -157,8 +157,12 @@ const PrimarySearchContainer: React.FC<{
   scheme: 'DEFAULT' | 'GROUP'
   flex?: number
 }> = ({ ...props }) => {
-  const history = useHistory()
-  return <PrimarySearch history={history} {...props} />
+  try {
+    const history = useHistory()
+    return <PrimarySearch history={history} {...props} />
+  } catch {
+    return <PrimarySearch history={history} {...props} />
+  }
 }
 
 export default PrimarySearchContainer

--- a/src/v2/hooks/useIsErrorPage/index.tsx
+++ b/src/v2/hooks/useIsErrorPage/index.tsx
@@ -1,0 +1,23 @@
+import { useApolloClient } from 'react-apollo'
+
+import ERROR_PAGE_QUERY from 'v2/hooks/useIsErrorPage/queries/isErrorPage'
+
+import { IsErrorPageQueryHook } from '__generated__/IsErrorPageQueryHook'
+
+export default function() {
+  const client = useApolloClient()
+
+  try {
+    const cache = client.readQuery<IsErrorPageQueryHook>({
+      query: ERROR_PAGE_QUERY,
+    })
+
+    const {
+      sharify: { isErrorPage },
+    } = cache
+
+    return isErrorPage
+  } catch {
+    return false
+  }
+}

--- a/src/v2/hooks/useIsErrorPage/queries/isErrorPage.ts
+++ b/src/v2/hooks/useIsErrorPage/queries/isErrorPage.ts
@@ -1,0 +1,9 @@
+import gql from 'graphql-tag'
+
+export default gql`
+  query IsErrorPageQueryHook {
+    sharify @client {
+      isErrorPage: IS_ERROR
+    }
+  }
+`


### PR DESCRIPTION
So apparently we already had a top bar on the error page, but when I refactored the topbar for client-side routing I broke it. This gets it rendering again, and makes search result items ordinary links when on the error page.