### PR TITLE
Solves 401 error when session is bad

### DIFF
--- a/src/apps/app/App.ts
+++ b/src/apps/app/App.ts
@@ -47,5 +47,5 @@ App.get(
 )
   .get('/group/:id/invite/:code', ensureLoggedIn, ...resolve)
   .get('/tools/*', ensureLoggedIn, ...resolve)
-  .get('/', homePathMiddleware, apolloMiddleware, ...resolve)
+  .get('/', homePathMiddleware, ...resolve)
   .get('*', ...resolve)

--- a/src/apps/app/App.ts
+++ b/src/apps/app/App.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express'
 import apolloMiddleware from 'v2/apollo/middleware'
 import homePathMiddleware from 'apps/app/middleware/homePath'
+import getFirstStatusCode from 'v2/util/getFirstStatusCode'
 
 import pageResolver from 'v2/components/UI/Page/resolver'
 import withStaticRouter from 'v2/hocs/WithStaticRouter'
@@ -20,7 +21,19 @@ const resolve = [
       .then(apolloRes => {
         pageResolver({ bundleName: 'app', apolloRes, res })
       })
-      .catch(next)
+      .catch(err => {
+        const STATUS_CODE = getFirstStatusCode(err)
+
+        if (STATUS_CODE === 'UNAUTHORIZED' && req.url === '/') {
+          // This typically happens if the serialized user is "bad"
+          // or not actually logged in. If so: logout, then redirect somewhere.
+          // Falling through by using `next()` doesn't seem to actually purge the session.
+          req.logout()
+          return res.redirect('/log_in')
+        }
+
+        return next(err)
+      })
   },
 ]
 
@@ -34,5 +47,5 @@ App.get(
 )
   .get('/group/:id/invite/:code', ensureLoggedIn, ...resolve)
   .get('/tools/*', ensureLoggedIn, ...resolve)
-  .get('/', homePathMiddleware, ...resolve)
+  .get('/', homePathMiddleware, apolloMiddleware, ...resolve)
   .get('*', ...resolve)

--- a/src/v2/components/GlobalNavElements/index.tsx
+++ b/src/v2/components/GlobalNavElements/index.tsx
@@ -37,7 +37,7 @@ export const GlobalNavElements: React.FC<GlobalNavElementsProps> = ({
         window.location.reload()
       )
     }
-  }, [data, error, isLoggedIn])
+  }, [error, isLoggedIn])
 
   const components = []
 

--- a/src/v2/components/GlobalNavElements/index.tsx
+++ b/src/v2/components/GlobalNavElements/index.tsx
@@ -25,7 +25,7 @@ export const GlobalNavElements: React.FC<GlobalNavElementsProps> = ({
   )
 
   useEffect(() => {
-    if (error && !isLoggedIn && error.graphQLErrors) {
+    if (error && error.graphQLErrors && isLoggedIn) {
       const {
         extensions: { code },
       } = error.graphQLErrors[0]
@@ -37,7 +37,7 @@ export const GlobalNavElements: React.FC<GlobalNavElementsProps> = ({
         window.location.reload()
       )
     }
-  }, [error, isLoggedIn])
+  }, [data, error, isLoggedIn])
 
   const components = []
 


### PR DESCRIPTION
Fixes ARE-7

We previously had this handler on the root route, so putting it back (though still don't understand exactly how a session can go bad). This also corrects the logic on `GlobalNavHandler` for logout > redirect on a client-side unauthenticated error.

