### PR TITLE
Add blocks module and epilogue to blog

### DIFF
--- a/src/v2/components/Cell/components/Konnectable/index.tsx
+++ b/src/v2/components/Cell/components/Konnectable/index.tsx
@@ -2,6 +2,7 @@ import React, { PureComponent } from 'react'
 import styled from 'styled-components'
 import { height, width, space } from 'styled-system'
 import { Link, useLocation } from 'react-router-dom'
+import { useQuery } from 'react-apollo'
 
 import { touch as isTouchDevice } from 'v2/util/is'
 
@@ -19,6 +20,8 @@ import KonnectableChannelOverlay from 'v2/components/Cell/components/Konnectable
 import useIsSpiderRequesting from 'v2/hooks/useIsSpiderRequesting'
 
 import { getBreadcrumbPath } from 'v2/util/getBreadcrumbPath'
+import BLOCK_QUERY from './queries/blokk'
+import { Blokk, BlokkVariables } from '__generated__/Blokk'
 
 const Container = styled(Link)`
   box-sizing: border-box;
@@ -66,7 +69,7 @@ interface State {
 }
 
 interface InnerProps {
-  location: any
+  location?: any
   isSpiderRequesting: boolean
 }
 
@@ -119,6 +122,8 @@ export class KonnectableInner extends PureComponent<Props & InnerProps> {
       children,
       context,
       isSpiderRequesting,
+      location,
+      ...rest
     } = this.props
 
     const defaultToParams = {
@@ -128,7 +133,7 @@ export class KonnectableInner extends PureComponent<Props & InnerProps> {
     }
 
     const toParams =
-      konnectable.__typename === 'Channel' || isSpiderRequesting
+      konnectable.__typename === 'Channel' || isSpiderRequesting || !location
         ? defaultToParams
         : {
             ...defaultToParams,
@@ -151,6 +156,7 @@ export class KonnectableInner extends PureComponent<Props & InnerProps> {
         data-no-instant={
           konnectable.__typename === 'Channel' ? undefined : true
         }
+        {...rest}
       >
         {children && children}
 
@@ -196,6 +202,35 @@ export const Konnectable: React.FC<Props> = props => {
       isSpiderRequesting={isSpiderRequesting}
       location={location}
       {...props}
+    />
+  )
+}
+
+interface BlockWithQueryProps {
+  id: string
+}
+
+export const BlokkWithQuery: React.FC<BlockWithQueryProps> = ({
+  id,
+  ...rest
+}) => {
+  const location = useLocation()
+  const { data, loading, error } = useQuery<Blokk, BlokkVariables>(
+    BLOCK_QUERY,
+    { variables: { id } }
+  )
+
+  if (loading || error) {
+    return <Container />
+  }
+
+  return (
+    <KonnectableInner
+      konnectable={data.blokk}
+      location={location}
+      isPreviewable
+      isSpiderRequesting={false}
+      {...rest}
     />
   )
 }

--- a/src/v2/pages/blog/BlogIndex/components/BlogPreview/index.tsx
+++ b/src/v2/pages/blog/BlogIndex/components/BlogPreview/index.tsx
@@ -48,13 +48,16 @@ interface BlogPreviewProps {
 export const BlogPreview: React.FC<BlogPreviewProps> = ({ post }) => {
   return (
     <Post href={`/blog/${post.slug}`} key={`post-${post.slug}`}>
-      <Image
-        srcSet={[
-          `${post.image.small} 250w`,
-          `${post.image.medium} 500w`,
-          `${post.image.large} 750w`,
-        ]}
-      />
+      {post.image && (
+        <Image
+          srcSet={[
+            `${post.image.small} 250w`,
+            `${post.image.medium} 500w`,
+            `${post.image.large} 750w`,
+          ]}
+        />
+      )}
+
       <Category>{post.category}</Category>
       <Title>{post.title}</Title>
       <Description>{post.previewText}</Description>

--- a/src/v2/pages/blog/BlogPost/components/BlogPostBlocks/index.tsx
+++ b/src/v2/pages/blog/BlogPost/components/BlogPostBlocks/index.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import styled from 'styled-components'
+import Box from 'v2/components/UI/Box'
+import { BlogPostInner } from '../BlogPostContent'
+import { BlokkWithQuery } from 'v2/components/Cell/components/Konnectable'
+
+import constants from 'v2/styles/constants'
+
+const Outer = styled(Box).attrs({ my: 9 })``
+
+const Container = styled(Box).attrs({ px: 5, pb: 5, my: 8 })`
+  border-left: 2px solid ${({ theme }) => theme.colors.gray.light};
+  border-right: 2px solid ${({ theme }) => theme.colors.gray.light};
+
+  display: flex;
+  flex-direction: row;
+
+  ${constants.media.mobile`
+    flex-direction: column;
+  `}
+`
+
+const TextContainer = styled(Box).attrs({ mr: 5 })``
+
+const BlockContainer = styled(Box).attrs({ ml: 5, pt: [8, 0] })`
+  display: flex;
+
+  ${constants.media.mobile`
+    margin: 0 auto;
+  `}
+`
+
+const Block = styled(BlokkWithQuery).attrs({
+  width: '225px',
+  height: '225px',
+})``
+
+interface BlogPostBlock {
+  sys: {
+    id: string
+  }
+  blockUrl: string
+  text: {
+    json: any
+  }
+}
+
+interface BlogPostBlocksProps {
+  blocks: BlogPostBlock[]
+}
+
+export const BlogPostBlocks: React.FC<BlogPostBlocksProps> = ({ blocks }) => {
+  return (
+    <Outer>
+      {blocks.map(block => {
+        const { text, blockUrl, sys } = block
+        const blockID = blockUrl.split('/').pop()
+
+        return (
+          <Container key={sys.id}>
+            <TextContainer>
+              <BlogPostInner content={text.json} />
+            </TextContainer>
+            <BlockContainer>
+              <Block id={blockID} />
+            </BlockContainer>
+          </Container>
+        )
+      })}
+    </Outer>
+  )
+}

--- a/src/v2/pages/blog/BlogPost/components/BlogPostContent/index.tsx
+++ b/src/v2/pages/blog/BlogPost/components/BlogPostContent/index.tsx
@@ -10,13 +10,9 @@ import HorizontalRule from 'v2/components/UI/HorizontalRule'
 
 import BLOG_POST_ASSETS_QUERY from 'v2/pages/blog/BlogPost/queries/BlogPostByID'
 
-interface BlogPostContentProps {
-  id: string
-  content: Document
-}
-
 const BaseText = styled(Text).attrs({
   my: 6,
+  f: 4,
   lineHeight: 2,
   underlineLinks: true,
 })``
@@ -60,7 +56,7 @@ const Blockquote = styled.blockquote`
   margin: ${({ theme }) => `${theme.space[8]} 0`};
 `
 
-const optionsWithEmbeds = (embedData: any) => {
+export const optionsWithEmbeds = (embedData: any) => {
   return {
     renderMark: {
       [MARKS.BOLD]: text => (
@@ -123,6 +119,28 @@ const optionsWithEmbeds = (embedData: any) => {
   }
 }
 
+interface BlogPostInnerProps {
+  content: Document
+  embedData?: any
+}
+
+export const BlogPostInner: React.FC<BlogPostInnerProps> = ({
+  content,
+  embedData,
+}) => {
+  const parsedContent = documentToReactComponents(
+    content,
+    optionsWithEmbeds(embedData)
+  )
+
+  return <Container>{parsedContent}</Container>
+}
+
+interface BlogPostContentProps {
+  id: string
+  content: Document
+}
+
 export const BlogPostContent: React.FC<BlogPostContentProps> = ({
   content,
   id,
@@ -132,10 +150,5 @@ export const BlogPostContent: React.FC<BlogPostContentProps> = ({
     variables: { id },
   })
 
-  const parsedContent = documentToReactComponents(
-    content,
-    optionsWithEmbeds(embedData)
-  )
-
-  return <Container>{parsedContent}</Container>
+  return <BlogPostInner content={content} embedData={embedData} />
 }

--- a/src/v2/pages/blog/BlogPost/index.tsx
+++ b/src/v2/pages/blog/BlogPost/index.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components'
 import moment from 'moment'
 
 import ErrorBoundary from 'v2/components/UI/ErrorBoundary'
-import Constrain from 'v2/components/UI/Constrain'
 import Description from 'v2/components/UI/Head/components/Description'
 import Image from 'v2/components/UI/Head/components/Image'
 
@@ -19,12 +18,13 @@ import { LoggedOutFooter } from 'v2/components/LoggedOutFooter'
 import { AboutTopBarLayout } from 'v2/components/UI/Layouts/AboutTopBarLayout'
 
 import BLOG_POST_CONTENT_QUERY from 'v2/pages/blog/BlogPost/queries/BlogPostBySlug'
+import { BlogPostBlocks } from './components/BlogPostBlocks'
 
 interface BlogPostProps {
   slug: string
 }
 
-const Container = styled(Box).attrs({ mt: 10, mx: 'auto' })`
+const Container = styled(Box).attrs({ mt: 10, mx: [5, 'auto'] })`
   max-width: 670px;
 `
 
@@ -64,25 +64,30 @@ export const BlogPost: React.FC<BlogPostProps> = ({ slug }) => {
     <ErrorBoundary>
       <Title>{post ? post.title : 'Blog'}</Title>
       <Description>{post && post.previewText}</Description>
-      <Image>{post && post.image.medium}</Image>
+      <Image>{post && post.image && post.image.medium}</Image>
 
       <AboutTopBarLayout>
-        <Constrain>
-          <Container>
-            <Category>{post.category}</Category>
-            <PostTitle>{post.title}</PostTitle>
+        <Container>
+          <Category>{post.category}</Category>
+          <PostTitle>{post.title}</PostTitle>
 
-            <Metadata>
-              <Meta>{moment(post.displayDate).format('LL')}</Meta>
-              <Meta>{post.author.name}</Meta>
-            </Metadata>
+          <Metadata>
+            <Meta>{moment(post.displayDate).format('LL')}</Meta>
+            <Meta>{post.author.name}</Meta>
+          </Metadata>
 
-            <BlogPostContent content={post.body.json} id={post.sys.id} />
-            {post.author.bio && (
-              <BlogPostAuthor author={post.author.bio.json} />
-            )}
-          </Container>
-        </Constrain>
+          <BlogPostContent content={post.body.json} id={post.sys.id} />
+
+          {post.blocksCollection.items.length > 0 && (
+            <BlogPostBlocks blocks={post.blocksCollection.items} />
+          )}
+
+          {post.epilogue && post.epilogue.json && (
+            <BlogPostContent content={post.epilogue.json} id={post.sys.id} />
+          )}
+
+          {post.author.bio && <BlogPostAuthor author={post.author.bio.json} />}
+        </Container>
         <BlogPostCTA />
         <LoggedOutFooter />
       </AboutTopBarLayout>

--- a/src/v2/pages/blog/BlogPost/queries/BlogPostBySlug.ts
+++ b/src/v2/pages/blog/BlogPost/queries/BlogPostBySlug.ts
@@ -11,6 +11,17 @@ export default gql`
         slug
         title
         category
+        blocksCollection {
+          items {
+            sys {
+              id
+            }
+            blockUrl
+            text {
+              json
+            }
+          }
+        }
         image {
           small: url(transform: { width: 250 })
           medium: url(transform: { width: 500 })
@@ -25,6 +36,10 @@ export default gql`
           }
         }
         body {
+          json
+        }
+
+        epilogue {
           json
         }
       }

--- a/src/v2/styles/constants.js
+++ b/src/v2/styles/constants.js
@@ -34,9 +34,9 @@ export const SPACING_SCALE = [
   '0.65625em',
   '0.75em',
   '1em', // 6
-  '2em',
-  '3em',
-  '4em',
+  '2em', // 7
+  '3em', // 8
+  '4em', // 9
   '8em',
   '16em',
   '24em',


### PR DESCRIPTION
Adds a way to "embed" blocks into blog posts, alongside a text description. See example.

![Screen Shot 2020-08-31 at 4 26 55 PM](https://user-images.githubusercontent.com/821469/91765330-ca56b500-eba6-11ea-8c73-69588ff70682.png)

