### PR TITLE
Fix reset password login for unconfirmed accounts

### DIFF
--- a/src/v2/components/ResetPasswordForm/index.js
+++ b/src/v2/components/ResetPasswordForm/index.js
@@ -56,10 +56,27 @@ class ResetPasswordForm extends Component {
         password_confirmation,
       },
     })
-      .then(({ data: { reset_password: { me: { email } } } }) => {
-        this.setState({ mode: 'logging_in', email })
-        return axios.post('/me/sign_in', { email, password })
-      })
+      .then(
+        ({
+          data: {
+            reset_password: {
+              me: { email },
+            },
+          },
+        }) => {
+          this.setState({ mode: 'logging_in', email })
+          return axios.post(
+            '/me/sign_in',
+            { email, password },
+            {
+              headers: {
+                // Sets `req.xhr` in Express
+                'X-Requested-With': 'XMLHttpRequest',
+              },
+            }
+          )
+        }
+      )
 
       .then(() => {
         this.setState({ mode: 'redirecting' })


### PR DESCRIPTION
Turns out Ervell was just returning a 500 when trying to login an unconfirmed account. This is apparently what we do on all other logging-in routes, and apparently it solved the problem here also.