### PR TITLE
Added Aria label for learn more link

### DIFF
--- a/src/v2/pages/about/PricingPage/index.js
+++ b/src/v2/pages/about/PricingPage/index.js
@@ -85,7 +85,7 @@ export default class PricingPage extends PureComponent {
           <br />
           students and educators.&nbsp;
           <strong>
-            <a href="/education">Learn more</a>
+            <a href="/education" role="link" aria-label="Learn more about our 50% discount on Premium plans for students and educators">Learn more</a>
           </strong>
         </Text>
         <GradientContent>


### PR DESCRIPTION
Added Aria label that reads  "Learn more about our 50% discount on Premium plans for students and educators" to aid those who use screen readers. It was just reading "learn more" when previewing on macOS voiceover.