### PR TITLE
Add maxSize and note sizes on drop overlay

### DIFF
--- a/src/v2/components/UI/DropZoneUploader/index.tsx
+++ b/src/v2/components/UI/DropZoneUploader/index.tsx
@@ -76,6 +76,7 @@ const DropZoneUploader: React.FC<Props> = ({
     noClick: true,
     noKeyboard: true,
     accept,
+    maxSize: 250000000, // 25mb
   })
 
   // Use `dragenter` event on `window` to trigger the actual drop-zone,
@@ -97,11 +98,16 @@ const DropZoneUploader: React.FC<Props> = ({
         <input {...getInputProps()} />
 
         <Backdrop>
-          {isDragActive && (
-            <Text f={9} color="gray.base" textAlign="center">
-              Drop files to add
-            </Text>
-          )}
+          {
+            <>
+              <Text f={7} color="gray.semiBold" textAlign="center">
+                Drop files to add
+              </Text>
+              <Text f={2} mt={6} color="gray.medium" textAlign="center">
+                Max file size for images is 25MB, and for all other files 250mb
+              </Text>
+            </>
+          }
 
           {mode === 'error' && (
             <Text


### PR DESCRIPTION
Responding to a fairly frequent question we get to help about uploading images or files to channel (about the maximum size, why certain images fail, etc). The ultimate idea would be to add custom validators to the drop zone (which apparently is possible: https://github.com/react-dropzone/react-dropzone/issues/321) which would communicate why a certain file was not valid.

I spent far too long trying to figure this out. The problem is that `acceptedFiles` is returned before a custom validator can can process the file (and there is no way to make those callbacks `async`). The only real option would be to overwrite `getFilesFromEvent`, but that is truly overkill. 

Maybe there is a better way to do this but right now I can't think of one.

Instead, just add the max file size for attachments, and add some help text to the drop zone overlay.