### PR TITLE
Fix styling on mobile links

### DIFF
--- a/src/v2/components/BlockLightbox/components/BlockLightboxLink/components/BlockLightboxLinkScreenshot/index.tsx
+++ b/src/v2/components/BlockLightbox/components/BlockLightboxLink/components/BlockLightboxLinkScreenshot/index.tsx
@@ -45,15 +45,17 @@ export const BlockLightboxLinkScreenshot: React.FC<BlockLightboxLinkProps> = ({
       display="flex"
       alignItems="center"
       justifyContent="center"
+      position="relative"
     >
       <Container
         display="flex"
         flexDirection="column"
-        height="95%"
+        height={['95vh', '95%']}
         width="90%"
         border="1px solid"
         borderColor="gray.light"
         borderRadius="0.25em"
+        position="relative"
       >
         <a
           href={block.source_url}


### PR DESCRIPTION
<img width="538" alt="Screen Shot 2021-05-10 at 12 47 03 PM" src="https://user-images.githubusercontent.com/821469/117695035-d3fcd780-b18d-11eb-82d5-ff12a4e20d34.png">
