### PR TITLE
Fix filter pane flashing when adding a new block to a channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "**/@typescript-eslint/parser": "^4.1.1"
   },
   "dependencies": {
-    "@apollo/client": "^3.4.7",
+    "@apollo/client": "^3.4.10",
     "@artsy/express-reloadable": "^1.5.0",
     "@auth0/s3": "^1.0.0",
     "@babel/core": "^7.0.0",

--- a/src/v2/components/ChannelContents/lib/usePaginatedBlocks.ts
+++ b/src/v2/components/ChannelContents/lib/usePaginatedBlocks.ts
@@ -350,7 +350,7 @@ export const usePaginatedBlocks = (unsafeArgs: {
   }, [client])
 
   /**
-   * Delete block cache and wipe queriedPageNumbersRef
+   * Refetch query and wipe queriedPageNumbersRef
    */
   const addBlock: UsePaginatedBlocksApi['addBlock'] = useCallback(() => {
     queriedPageNumbersRef.current = new Set()

--- a/src/v2/components/ChannelContents/lib/usePaginatedBlocks.ts
+++ b/src/v2/components/ChannelContents/lib/usePaginatedBlocks.ts
@@ -354,12 +354,11 @@ export const usePaginatedBlocks = (unsafeArgs: {
    */
   const addBlock: UsePaginatedBlocksApi['addBlock'] = useCallback(() => {
     queriedPageNumbersRef.current = new Set()
-    updateCache(({ blockArgs: [_prevBlocks, { DELETE }] }) => {
-      return {
-        newBlocks: DELETE,
-      }
+    client.refetchQueries({
+      include: [channelBlokksPaginatedQuery],
+      optimistic: true,
     })
-  }, [updateCache])
+  }, [client])
 
   // ==============================
   // Build and return the final api

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@apollo/client@^3.4.7":
-  version "3.4.7"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.4.7.tgz#63d7c3539cc45fe44ac9cb093a27641479a8d1ad"
-  integrity sha512-EmqGxXD8hr05cIFWJFwtGXifc+Lo8hTCEuiaQMtKknHszJfqIFXSxqP+H+eJnjfuoxH74aTSsZKtJlnE83Vt6w==
+"@apollo/client@^3.4.10":
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.4.10.tgz#cee9ed75b1bb7f391c55d79300ecf87096e59792"
+  integrity sha512-b+8TT3jBM2BtEJi+V2FuLpvoYDZCY3baNYrgAgEyw4fjnuBCSRPY7qVjqriZAwMaGiTLtyVifGhmdeICQs4Eow==
   dependencies:
     "@graphql-typed-document-node/core" "^3.0.0"
     "@wry/context" "^0.6.0"


### PR DESCRIPTION
This fixes an issue where the filter pane unmounts then remounts when a block is added. The reason is that the filter pane depends on the same cache value that the grid uses, and the previous mechanism of reloading the grid after an "add block" event was to delete the block cache. Deleting a cache value forces any queries watching that cache to reload.

This new approach keeps the previous block cache in memory while new data is loaded through the new cool "refetchQueries" api https://www.apollographql.com/docs/react/data/refetching/

https://user-images.githubusercontent.com/4934193/132137432-1ad55187-1e3c-433b-8391-ca9126f97e34.mov

