### PR TITLE
Fix pusher updating for new blocks transitioning to processed blocks

### DIFF
--- a/src/v2/components/ChannelContents/index.tsx
+++ b/src/v2/components/ChannelContents/index.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useEffect, useCallback } from 'react'
+import React, { memo, useCallback } from 'react'
 import { SortableContainer } from 'react-sortable-hoc'
 
 import { ChannelContents as ChannelContentsData } from '__generated__/ChannelContents'
@@ -20,8 +20,6 @@ const SortableGrid = SortableContainer(({ onSortEnd: _onSortEnd, ...rest }) => (
 
 interface Props {
   channel: ChannelContentsData
-  pusherChannel?: any
-  socket?: any
 }
 
 interface ExtendedProps extends Props {
@@ -51,7 +49,7 @@ const parsePayload = (payload: any): PusherPayload => {
 }
 
 const ChannelContents: React.FC<Props> = WithIsSpiderRequesting<ExtendedProps>(
-  memo(({ channel, pusherChannel, socket, isSpiderRequesting, ...rest }) => {
+  memo(({ channel, isSpiderRequesting, ...rest }) => {
     const {
       blocks,
       getPage,
@@ -106,20 +104,12 @@ const ChannelContents: React.FC<Props> = WithIsSpiderRequesting<ExtendedProps>(
     )
 
     usePusher({
-      channel: pusherChannel,
+      channelId: channel.id,
+      skip: !isSpiderRequesting,
       onCreated: addBlock,
       onUpdated: updateConnectable,
       parsePayload: parsePayload,
     })
-
-    useEffect(() => {
-      return () => {
-        if (pusherChannel) {
-          socket.unsubscribe(pusherChannel.name)
-          socket.disconnect()
-        }
-      }
-    }, [pusherChannel, socket])
 
     // For the lightbox, we need to filter out channels
     const lightboxConnectables = blocks.filter(

--- a/src/v2/components/ChannelContents/index.tsx
+++ b/src/v2/components/ChannelContents/index.tsx
@@ -105,7 +105,7 @@ const ChannelContents: React.FC<Props> = WithIsSpiderRequesting<ExtendedProps>(
 
     usePusher({
       channelId: channel.id,
-      skip: !isSpiderRequesting,
+      shouldSubscribe: !isSpiderRequesting && channel.can.add_to,
       onCreated: addBlock,
       onUpdated: updateConnectable,
       parsePayload: parsePayload,

--- a/src/v2/components/ChannelContents/lib/usePaginatedBlocks.ts
+++ b/src/v2/components/ChannelContents/lib/usePaginatedBlocks.ts
@@ -68,6 +68,7 @@ export const usePaginatedBlocks = (unsafeArgs: {
       per: channelBlokksPaginatedPerPage,
     },
     ssr: args.current.ssr,
+    context: { queryDeduplication: false },
   })
 
   /**

--- a/src/v2/hooks/usePusher/index.tsx
+++ b/src/v2/hooks/usePusher/index.tsx
@@ -39,14 +39,14 @@ export const usePusher = ({
    */
   useEffect(() => {
     const pusher: Pusher | false = initPusherClient()
-    const pusherChannel =
+    const channel =
       !skip && pusher && pusher.subscribe(`channel-${NODE_ENV}-${channelId}`)
 
-    setChannel(pusherChannel)
+    setChannel(channel)
 
     return () => {
-      pusherChannel.unsubscribe()
-      pusherChannel.disconnect()
+      channel.unsubscribe()
+      channel.disconnect()
 
       setChannel(false)
     }

--- a/src/v2/hooks/usePusher/index.tsx
+++ b/src/v2/hooks/usePusher/index.tsx
@@ -79,7 +79,7 @@ export const usePusher = ({
         channel.unbind()
       }
     }
-  }, [channelId, onCreated, onUpdated, parsePayload, channel, skip])
+  }, [onCreated, onUpdated, parsePayload, channel])
 
   return payloads
 }

--- a/src/v2/hooks/usePusher/index.tsx
+++ b/src/v2/hooks/usePusher/index.tsx
@@ -12,7 +12,7 @@ export function normalizePayloads(payloads) {
 
 interface PusherHook {
   channelId: number
-  skip: boolean
+  shouldSubscribe?: boolean
   onCreated?: (payload: any) => any
   onUpdated?: (payload: any) => any
   parsePayload?: (payload: any) => any
@@ -26,7 +26,7 @@ const {
 
 export const usePusher = ({
   channelId,
-  skip,
+  shouldSubscribe = true,
   onCreated = emptyFn,
   onUpdated = emptyFn,
   parsePayload = emptyFn,
@@ -40,7 +40,9 @@ export const usePusher = ({
   useEffect(() => {
     const pusher: Pusher | false = initPusherClient()
     const channel =
-      !skip && pusher && pusher.subscribe(`channel-${NODE_ENV}-${channelId}`)
+      shouldSubscribe &&
+      pusher &&
+      pusher.subscribe(`channel-${NODE_ENV}-${channelId}`)
 
     setChannel(channel)
 
@@ -50,7 +52,7 @@ export const usePusher = ({
 
       setChannel(false)
     }
-  }, [channelId, skip])
+  }, [channelId, shouldSubscribe])
 
   /**
    * Effect to bind and unbind callbacks to the events

--- a/src/v2/pages/channel/components/ChannelContentsWithData/index.tsx
+++ b/src/v2/pages/channel/components/ChannelContentsWithData/index.tsx
@@ -1,16 +1,13 @@
 import React from 'react'
 import { Query } from '@apollo/client/react/components'
-import sharify from 'sharify'
 
 import {
   ChannelContentsWithData as ChannelContentsWithDataData,
   ChannelContentsWithDataVariables,
 } from '__generated__/ChannelContentsWithData'
 
-import { setupPusherChannel } from 'v2/hooks/usePusher'
 import { channelContentsWithDataQuery } from 'v2/pages/channel/components/ChannelContentsWithData/queries/channelContentsWithData'
 
-import WithIsSpiderRequesting from 'v2/hocs/WithIsSpiderRequesting'
 import ErrorAlert from 'v2/components/UI/ErrorAlert'
 import ChannelContents from 'v2/components/ChannelContents'
 import { ChannelContentsPlaceholder } from 'v2/components/ChannelContentsPlaceholder'
@@ -21,17 +18,9 @@ interface Props {
   }
 }
 
-interface ExtendedProps extends Props {
-  isSpiderRequesting: boolean
-}
-
-const {
-  data: { NODE_ENV },
-} = sharify
-
-export const ChannelContentsWithData: React.FC<Props> = WithIsSpiderRequesting<
-  ExtendedProps
->(({ channel: serverChannel, isSpiderRequesting }) => {
+export const ChannelContentsWithData: React.FC<Props> = ({
+  channel: serverChannel,
+}) => {
   return (
     <Query<ChannelContentsWithDataData, ChannelContentsWithDataVariables>
       query={channelContentsWithDataQuery}
@@ -49,25 +38,8 @@ export const ChannelContentsWithData: React.FC<Props> = WithIsSpiderRequesting<
         const { channel: clientChannel } = data
         const channel = { ...serverChannel, ...clientChannel }
 
-        const shouldSubscribeToPusher =
-          !isSpiderRequesting && channel.can.add_to
-
-        if (shouldSubscribeToPusher) {
-          const { channel: pusherChannel, socket } = setupPusherChannel(
-            `channel-${NODE_ENV}-${channel.id}`
-          )
-
-          return (
-            <ChannelContents
-              channel={channel}
-              socket={socket}
-              pusherChannel={pusherChannel}
-            />
-          )
-        }
-
         return <ChannelContents channel={channel} />
       }}
     </Query>
   )
-})
+}


### PR DESCRIPTION
This PR potentially fixes a bug where a PendingBlock will never update to the final block.

While investigating the issue I came up with 2 potential issues:

1. A new pusher client is initialized every time a channel page is updated. If you go to a channel and add 4 blocks to it, you can see in the network tab that multiple pusher connections are established:

<img width="443" alt="Screen Shot 2021-09-20 at 3 55 23 PM" src="https://user-images.githubusercontent.com/4934193/134101863-f95ebb2b-df9f-488f-8375-266aa4fde2a7.png">

This creates the possibility of a window of time, after the first channel disconnects and before the new one connects, where an update event can come in and not get captured.

2. Query deduplication is on for usePaginatedBlocks calls. Query deduplication is a heuristic that apollo implements which tries to cancel queries if the same query is currently in-flight. This means that if `getPage(1)` was called a few seconds ago, another call to `getPage(1)` would get pointed to the first (potentially out of date) query instead of making a new network call.

It's kind of a bummer that this issue is flakey but I'm feeling pretty confident that it's happening because of one or a combination of these reasons. If my changes don't solve the issue we can do a more aggressive fix but it will really increase the complexity of the usePaginatedBlocks callback, which I'd rather not do unless totally necessary. These changes I'm introducing are beneficial regardless of the bug or not though, so not all would be lost if this doesn't work out :)
