### PR TITLE
Fix: Single Quote not showing in Education section of about page because of wrong HTML entity

### DIFF
--- a/src/v2/pages/about/AboutPage/components/EducationCTA/index.tsx
+++ b/src/v2/pages/about/AboutPage/components/EducationCTA/index.tsx
@@ -12,8 +12,8 @@ export const EducationCTA: React.FC = ({ ...rest }) => {
       </P>
 
       <P>
-        If you&#139;re a student, you can get 50% off the price of any Premium
-        plan for two years. If you&#139;re a teacher and use Are.na with your
+        If you&#39;re a student, you can get 50% off the price of any Premium
+        plan for two years. If you&#39;re a teacher and use Are.na with your
         class <a href="mailto:help@are.na">contact us</a> for assistance and
         custom discounts for your students.
       </P>


### PR DESCRIPTION
# How it looks like in production right now in chromium based browsers:
<img width="616" alt="image" src="https://github.com/aredotna/ervell/assets/81759594/37e39fca-5f9e-4028-be65-7595419c84de">

# Firefox:
<img width="607" alt="image" src="https://github.com/aredotna/ervell/assets/81759594/731f52ff-7222-47f4-be8b-ebd7d6e15db5">

# Safari:
<img width="642" alt="image" src="https://github.com/aredotna/ervell/assets/81759594/1d8641b3-3ba3-477c-89d8-c9cbae92ba45">
