### PR TITLE
Removed upcoming price changes

### DIFF
--- a/src/v2/pages/about/PricingPage/index.tsx
+++ b/src/v2/pages/about/PricingPage/index.tsx
@@ -53,13 +53,6 @@ const PricingPage: React.FC = () => {
         <PricingTable />
 
         <CTAContainer>
-          <Box display="flex" alignItems="center" justifyContent="center">
-            <Icons name="QuestionCircle" size="1em" mr={4} color="gray.bold" />
-            <Text f={4} color="gray.bold" textAlign="center">
-              Upcoming changes on January 15th, 2023
-            </Text>
-          </Box>
-
           <Text f={4} color="gray.bold" textAlign="center">
             Read our{' '}
             <strong>


### PR DESCRIPTION
This was introduced at the beginning of the year, and is no longer relevant.